### PR TITLE
docs: restructure README introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,29 +307,6 @@ python -m pytest skillcorpus/tests -p no:cacheprovider --import-mode=importlib
 - [x] Plugins for WorkBuddy · Hermes · OpenClaw · DeepSeek Harness (+ HTTP adapter for any other host)
 - [ ] Raven plugin — packaged, waiting on the upstream `context_segments` slot
 
-## Citation
-
-```bibtex
-@article{wang2026skillcorpus,
-  title         = {SkillCorpus: Consolidating and Evaluating the Open Skill Ecosystem for Real-World LLM Agents},
-  author        = {Wang, Yanze and Yao, Pengfei and Sun, Tianyi and Hu, Chuanrui and Xiao, Yan and Luo, Xiaotian and Han, Yunyun and Chen, Yifan and Sun, Jun and Deng, Yafeng},
-  year          = {2026},
-  eprint        = {2607.15557},
-  archivePrefix = {arXiv},
-  url           = {https://arxiv.org/abs/2607.15557}
-}
-```
-
-## License
-
-- **Code** — Apache-2.0 (the `match/` and `evaluate/` toolkits are each MIT — see their own `LICENSE`).
-- **Corpus** — every skill keeps its **original upstream license**; only GREEN
-  (MIT / Apache-2.0 / BSD / ISC / …) skills are included, none relicensed. Each row carries
-  `source`, `source_url`, and `license`, so downstream use must follow the per-skill terms.
-
-Full GREEN/RED/YELLOW policy, license data flow, and opt-out:
-[`docs/licence-and-governance.md`](docs/licence-and-governance.md).
-
 ## EverMind Ecosystem
 
 EverMind is an open-source ecosystem for long-term memory, self-evolving agents, AI-native interfaces, and memory evaluation.
@@ -377,3 +354,26 @@ EverMind is an open-source ecosystem for long-term memory, self-evolving agents,
 </table>
 
 Together, these repositories form EverMind's research-to-runtime stack: new memory methods, reusable algorithms, benchmark evidence, and practical agent integrations.
+
+## Citation
+
+```bibtex
+@article{wang2026skillcorpus,
+  title         = {SkillCorpus: Consolidating and Evaluating the Open Skill Ecosystem for Real-World LLM Agents},
+  author        = {Wang, Yanze and Yao, Pengfei and Sun, Tianyi and Hu, Chuanrui and Xiao, Yan and Luo, Xiaotian and Han, Yunyun and Chen, Yifan and Sun, Jun and Deng, Yafeng},
+  year          = {2026},
+  eprint        = {2607.15557},
+  archivePrefix = {arXiv},
+  url           = {https://arxiv.org/abs/2607.15557}
+}
+```
+
+## License
+
+- **Code** — Apache-2.0 (the `match/` and `evaluate/` toolkits are each MIT — see their own `LICENSE`).
+- **Corpus** — every skill keeps its **original upstream license**; only GREEN
+  (MIT / Apache-2.0 / BSD / ISC / …) skills are included, none relicensed. Each row carries
+  `source`, `source_url`, and `license`, so downstream use must follow the per-skill terms.
+
+Full GREEN/RED/YELLOW policy, license data flow, and opt-out:
+[`docs/licence-and-governance.md`](docs/licence-and-governance.md).

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@
 </table>
 
 <p align="center">
-  <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge&logo=huggingface&logoColor=white" alt="Hugging Face"></a>
-  <a href="https://evermind.ai/skillhub"><img src="https://img.shields.io/badge/SkillHub-live-2ea44f?labelColor=gray&style=for-the-badge" alt="SkillHub"></a>
-  <a href="https://discord.gg/gYep5nQRZJ"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FgYep5nQRZJ%3Fwith_counts%3Dtrue&query=%24.approximate_presence_count&suffix=%20online&label=Discord&color=404EED&labelColor=gray&style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
-  <a href="https://github.com/EverMind-AI/EverOS/discussions/67"><img src="https://img.shields.io/badge/WeCom-EverMind_Community-07C160?labelColor=gray&style=for-the-badge&logo=wechat&logoColor=white" alt="WeCom"></a>
   <a href="https://arxiv.org/abs/2607.15557"><img src="https://img.shields.io/badge/arXiv-2607.15557-b31b1b?labelColor=gray&style=for-the-badge" alt="Paper"></a>
+  <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge&logo=huggingface&logoColor=white" alt="Hugging Face"></a>
+  <a href="https://discord.gg/gYep5nQRZJ"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FgYep5nQRZJ%3Fwith_counts%3Dtrue&query=%24.approximate_presence_count&suffix=%20online&label=Discord&color=404EED&labelColor=gray&style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://github.com/EverMind-AI/EverOS/discussions/67"><img src="https://img.shields.io/badge/WeCom-EverMind_%E7%A4%BE%E5%8C%BA-07C160?labelColor=gray&style=for-the-badge&logo=wechat&logoColor=white" alt="WeCom"></a>
 </p>
 
 <p align="center"><strong>English</strong> · <a href="README.zh-CN.md">简体中文</a></p>

--- a/README.md
+++ b/README.md
@@ -7,44 +7,41 @@
 <tr><td><img src="https://github.com/user-attachments/assets/2ef7e877-275d-4115-8ddf-f9b49de8ff5d" alt="SkillCorpus banner" width="100%"></td></tr>
 </table>
 
-[![Paper](https://img.shields.io/badge/arXiv-2607.15557-b31b1b.svg)](https://arxiv.org/abs/2607.15557)
-[![SkillHub](https://img.shields.io/badge/SkillHub-live-2ea44f.svg)](https://evermind.ai/skillhub)
-[![License](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](#license)
-![Python](https://img.shields.io/badge/python-3.10+-blue.svg)
+<p align="center">
+  <a href="https://github.com/EverMind-AI/SkillCorpus"><img src="https://img.shields.io/badge/SkillCorpus-EverMind_Open--Source-000000?labelColor=gray&style=for-the-badge&logo=github&logoColor=white" alt="SkillCorpus"></a>
+  <a href="https://evermind.ai/skillhub"><img src="https://img.shields.io/badge/SkillHub-live-2ea44f?labelColor=gray&style=for-the-badge" alt="SkillHub"></a>
+  <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge&logo=huggingface&logoColor=white" alt="Hugging Face"></a>
+  <a href="https://arxiv.org/abs/2607.15557"><img src="https://img.shields.io/badge/arXiv-2607.15557-b31b1b?labelColor=gray&style=for-the-badge" alt="Paper"></a>
+</p>
 
-**English** | [简体中文](README.zh-CN.md)
+<p align="center"><a href="https://evermind.ai/skillhub">SkillHub</a> · <strong>English</strong> · <a href="README.zh-CN.md">简体中文</a></p>
 
 
 </div>
 
+<br>
+
+## What SkillCorpus gives you
+
 SkillCorpus is EverMind's open-source pipeline for turning scattered `SKILL.md` files from public
 repositories into reliable agent context. It aggregates sources, applies safety and license gates,
-evaluates quality, and matches task-specific skills before the agent answers. The public 1,000-skill
-demo, three agent benchmarks, and live [SkillHub](https://evermind.ai/skillhub) show the result;
-clone this repository when you want to build, modify, or self-host the open-source core.
+evaluates quality, and matches task-specific skills before the agent answers.
+
+You can use the live [SkillHub](https://evermind.ai/skillhub) without cloning this repository. Clone
+SkillCorpus when you want the open-source machinery behind that experience:
+
+- **Build your own skill layer** — point the pipeline at your own source registry, apply the
+  curation, safety, and license gates, and export a corpus for your agents.
+- **Change the behavior** — modify the taxonomy, quality and dedup rules, retrieval recipe, export
+  schema, evaluation suites, or host plugins.
+- **Keep control of deployment** — self-host the released retrieval models and connect your own
+  agent host instead of using the hosted SkillHub API.
+
+The core code is Apache-2.0 licensed (`match/` and `evaluate/` are MIT); each skill retains its
+upstream license. The public 1,000-skill demo, three agent benchmarks, and live SkillHub show the
+result.
 
 https://github.com/user-attachments/assets/4d9a3241-df13-4b20-9798-fb7920069995
-
-<details>
-  <summary><kbd>Table of Contents</kbd></summary>
-
-<br>
-
-- [Stronger agents, one turn at a time](#stronger-agents-one-turn-at-a-time)
-- [Results](#results)
-- [Public artifacts](#public-artifacts)
-- [What SkillCorpus gives you](#what-skillcorpus-gives-you)
-- [SkillHub for your agent host](#skillhub-for-your-agent-host)
-- [News](#news)
-- [Other ways to use it](#other-ways-to-use-it)
-- [How it works](#how-it-works)
-- [Build your own corpus](#build-your-own-corpus)
-- [Roadmap](#roadmap)
-- [EverMind Ecosystem](#evermind-ecosystem)
-
-<br>
-
-</details>
 
 ## Stronger agents, one turn at a time
 
@@ -115,22 +112,6 @@ service is closed, and the full hosted catalog is not yet published as a downloa
 The 96,401-skill snapshot measured in the paper, organised by a 16-class taxonomy and three quality facets
 (utility / robustness / safety), with 1024-dim retrieval embeddings. Column contract:
 [`docs/corpus-schema.md`](docs/corpus-schema.md).
-
-## What SkillCorpus gives you
-
-You can use the live [SkillHub](https://evermind.ai/skillhub) without cloning this repository. Clone
-SkillCorpus when you want the open-source machinery behind that experience:
-
-- **Build your own skill layer** — point the pipeline at your own source registry, apply the
-  curation, safety, and license gates, and export a corpus for your agents.
-- **Change the behavior** — modify the taxonomy, quality and dedup rules, retrieval recipe, export
-  schema, evaluation suites, or host plugins.
-- **Keep control of deployment** — self-host the released retrieval models and connect your own
-  agent host instead of using the hosted SkillHub API.
-
-The core code is Apache-2.0 licensed (`match/` and `evaluate/` are MIT); each skill retains its
-upstream license. Start with [Build your own corpus](#build-your-own-corpus), or use SkillHub first
-to see the result before changing the machinery.
 
 ## SkillHub for your agent host
 

--- a/README.md
+++ b/README.md
@@ -138,18 +138,7 @@ The 96,401-skill snapshot measured in the paper, organised by a 16-class taxonom
 (utility / robustness / safety), with 1024-dim retrieval embeddings. Column contract:
 [`docs/corpus-schema.md`](docs/corpus-schema.md).
 
-## News
-
-- **2026-08-19** — **SkillCorpus Plugins** shipped: per-turn retrieval inside WorkBuddy, Hermes, OpenClaw and DeepSeek Harness.
-- **2026-08-12** — Retrieval models (bi-encoder + reranker) and a 1,000-skill demo corpus on [🤗 HuggingFace](https://huggingface.co/EverMind-AI).
-- **2026-08-06** — Paper v5 on [arXiv](https://arxiv.org/abs/2607.15557).
-
-## Other ways to use it
-
-The plugin above covers most people. If you would rather call the service yourself, or run
-the whole thing on your own hardware:
-
-### Query the API directly
+## Query the API directly
 
 [SkillHub](https://evermind.ai/skillhub) serves the corpus in three tiers — discover
 (metadata), read (`skill_md`), download (zip with `scripts/`). Most skills are pure
@@ -194,7 +183,7 @@ task: extract tables from a scanned PDF invoice
 Endpoints, response envelope, status codes and rate limits:
 [`docs/integrations.md`](docs/integrations.md).
 
-### Self-host the models
+## Self-host the models
 
 To avoid depending on the hosted endpoint, run selection yourself. The corpus and both
 retrieval models are released: load the data, serve the two models, and run your own

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ result.
 
 https://github.com/user-attachments/assets/4d9a3241-df13-4b20-9798-fb7920069995
 
+<br>
+
 ## Stronger agents, one turn at a time
 
 At answer time, the practical difference is a retrieval layer: SkillHub selects vetted procedural
@@ -73,6 +75,8 @@ knowledge for the task and puts it into the agent's context.
 The result is the same agent with better task-specific procedures available at the moment it needs
 them — stronger execution without asking users to memorise skill names or wire up tool calls.
 
+<br>
+
 ## Results
 
 Pass rate with no skills → with SkillCorpus, same harness, same backbone
@@ -88,6 +92,8 @@ Pass rate with no skills → with SkillCorpus, same harness, same backbone
 
 The gain is largest where the task needs procedural knowledge the model does not already have
 (SkillsBench), and smallest on open-ended economic tasks it can already do (GDPVal).
+
+<br>
 
 ## SkillHub integrations
 
@@ -115,6 +121,8 @@ Paste that line to your agent and it installs itself. Per-host setup, the five s
 will actually touch, what each turn costs and what leaves your machine —
 **[`skillcorpus_plugin/`](skillcorpus_plugin)**.
 
+<br>
+
 ## Public artifacts
 
 This is the concrete inventory of what is public today.
@@ -137,6 +145,8 @@ service is closed, and the full hosted catalog is not yet published as a downloa
 The 96,401-skill snapshot measured in the paper, organised by a 16-class taxonomy and three quality facets
 (utility / robustness / safety), with 1024-dim retrieval embeddings. Column contract:
 [`docs/corpus-schema.md`](docs/corpus-schema.md).
+
+<br>
 
 ## Query the API directly
 
@@ -183,6 +193,8 @@ task: extract tables from a scanned PDF invoice
 Endpoints, response envelope, status codes and rate limits:
 [`docs/integrations.md`](docs/integrations.md).
 
+<br>
+
 ## Self-host the models
 
 To avoid depending on the hosted endpoint, run selection yourself. The corpus and both
@@ -218,6 +230,8 @@ drop-in for SkillHub's hosted-only `/openapi/v1/skills` API. So:
   `embedding.provider: skillrouter_remote` to [build your own corpus](#build-your-own) with it.
 
 To curate **your own** sources instead, see [Build your own corpus](#build-your-own).
+
+<br>
 
 ## How it works
 
@@ -257,6 +271,8 @@ always runs end to end.
 
 <a name="build-your-own"></a>
 
+<br>
+
 ## Build your own corpus
 
 Only needed if you want to curate **your own** sources. Requires an LLM endpoint for
@@ -283,6 +299,8 @@ pip install -e ".[dev]"
 python -m pytest skillcorpus/tests -p no:cacheprovider --import-mode=importlib
 ```
 
+<br>
+
 ## Roadmap
 
 <!-- TODO(@team): this is a first pass from known gaps — edit to match your plan. -->
@@ -295,6 +313,8 @@ python -m pytest skillcorpus/tests -p no:cacheprovider --import-mode=importlib
 - [x] Deployment script for the two retrieval models (self-hosting `match/`)
 - [x] Plugins for WorkBuddy · Hermes · OpenClaw · DeepSeek Harness (+ HTTP adapter for any other host)
 - [ ] Raven plugin — packaged, waiting on the upstream `context_segments` slot
+
+<br>
 
 ## EverMind Ecosystem
 
@@ -344,6 +364,8 @@ EverMind is an open-source ecosystem for long-term memory, self-evolving agents,
 
 Together, these repositories form EverMind's research-to-runtime stack: new memory methods, reusable algorithms, benchmark evidence, and practical agent integrations.
 
+<br>
+
 ## Citation
 
 ```bibtex
@@ -356,6 +378,8 @@ Together, these repositories form EverMind's research-to-runtime stack: new memo
   url           = {https://arxiv.org/abs/2607.15557}
 }
 ```
+
+<br>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,12 @@
 </table>
 
 <p align="center">
-  <a href="https://github.com/EverMind-AI/SkillCorpus"><img src="https://img.shields.io/badge/SkillCorpus-EverMind_Open--Source-000000?labelColor=gray&style=for-the-badge&logo=github&logoColor=white" alt="SkillCorpus"></a>
   <a href="https://evermind.ai/skillhub"><img src="https://img.shields.io/badge/SkillHub-live-2ea44f?labelColor=gray&style=for-the-badge" alt="SkillHub"></a>
   <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge&logo=huggingface&logoColor=white" alt="Hugging Face"></a>
   <a href="https://arxiv.org/abs/2607.15557"><img src="https://img.shields.io/badge/arXiv-2607.15557-b31b1b?labelColor=gray&style=for-the-badge" alt="Paper"></a>
 </p>
 
-<p align="center"><a href="https://evermind.ai/skillhub">SkillHub</a> · <strong>English</strong> · <a href="README.zh-CN.md">简体中文</a></p>
+<p align="center"><strong>English</strong> · <a href="README.zh-CN.md">简体中文</a></p>
 
 
 </div>

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 </table>
 
 <p align="center">
-  <a href="https://arxiv.org/abs/2607.15557"><img src="https://img.shields.io/badge/arXiv-2607.15557-b31b1b?labelColor=gray&style=for-the-badge" alt="Paper"></a>
-  <a href="https://evermind.ai/skillhub"><img src="https://img.shields.io/badge/SkillHub-live-2ea44f?labelColor=gray&style=for-the-badge" alt="SkillHub"></a>
   <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge&logo=huggingface&logoColor=white" alt="Hugging Face"></a>
+  <a href="https://evermind.ai/skillhub"><img src="https://img.shields.io/badge/SkillHub-live-2ea44f?labelColor=gray&style=for-the-badge" alt="SkillHub"></a>
+  <a href="https://discord.gg/gYep5nQRZJ"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FgYep5nQRZJ%3Fwith_counts%3Dtrue&query=%24.approximate_presence_count&suffix=%20online&label=Discord&color=404EED&labelColor=gray&style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://github.com/EverMind-AI/EverOS/discussions/67"><img src="https://img.shields.io/badge/WeCom-EverMind_Community-07C160?labelColor=gray&style=for-the-badge&logo=wechat&logoColor=white" alt="WeCom"></a>
+  <a href="https://arxiv.org/abs/2607.15557"><img src="https://img.shields.io/badge/arXiv-2607.15557-b31b1b?labelColor=gray&style=for-the-badge" alt="Paper"></a>
 </p>
 
 <p align="center"><strong>English</strong> · <a href="README.zh-CN.md">简体中文</a></p>

--- a/README.md
+++ b/README.md
@@ -89,32 +89,9 @@ Pass rate with no skills → with SkillCorpus, same harness, same backbone
 The gain is largest where the task needs procedural knowledge the model does not already have
 (SkillsBench), and smallest on open-ended economic tasks it can already do (GDPVal).
 
-## Public artifacts
+## SkillHub integrations
 
-This is the concrete inventory of what is public today.
-
-| | Artifact | What | Link |
-|---|---|---|---|
-| 🌐 | **SkillHub** | the current 114,190-skill catalog + the two models, hosted as an API — no install | [evermind.ai/skillhub](https://evermind.ai/skillhub) |
-| 📚 | **Corpus** *(demo)* | the downloadable 1,000-skill sample — `skills.parquet` + `attachments.tar.zst` + dataset card; the full catalog is served by SkillHub | [🤗 demo-1k](https://huggingface.co/datasets/EverMind-AI/skillcorpus-demo-1k) |
-| 🔡 | **Retrieval models** | a bi-encoder and a reranker, fine-tuned from `Qwen3-Embedding-0.6B` and `Qwen3-Reranker-0.6B` | [🤗 bi-encoder](https://huggingface.co/EverMind-AI/skillcorpus-embedding-0.6b) · [reranker](https://huggingface.co/EverMind-AI/skillcorpus-reranker-0.6b) |
-| 🛠️ | **Code** | this repo — the pipeline that builds the corpus and trains the two models (`aggregate` · `curate` · `match` · `evaluate` · `export`) | [GitHub](https://github.com/EverMind-AI/SkillCorpus) |
-| 🔌 | **Plugins** | packaged host adapters for OpenClaw · Hermes · WorkBuddy · Raven, plus DeepSeek Harness and an HTTP adapter | [`skillcorpus_plugin/`](skillcorpus_plugin) |
-
-*Open source today: the code, 1,000-skill demo corpus, and retrieval models. The hosted SkillHub
-service is closed, and the full hosted catalog is not yet published as a downloadable dataset.*
-
-<div align="center">
-<img src="docs/assets/taxonomy.png" alt="16-class distribution over the 96,401 active skills" width="58%">
-</div>
-
-The 96,401-skill snapshot measured in the paper, organised by a 16-class taxonomy and three quality facets
-(utility / robustness / safety), with 1024-dim retrieval embeddings. Column contract:
-[`docs/corpus-schema.md`](docs/corpus-schema.md).
-
-## SkillHub for your agent host
-
-SkillHub brings per-turn skill retrieval to the five hosts below. Choose your host to open its
+SkillHub brings per-turn skill retrieval to the five agent platforms below. Choose a platform to open its
 plugin guide:
 
 <table width="100%">
@@ -137,6 +114,29 @@ working today.
 Paste that line to your agent and it installs itself. Per-host setup, the five settings you
 will actually touch, what each turn costs and what leaves your machine —
 **[`skillcorpus_plugin/`](skillcorpus_plugin)**.
+
+## Public artifacts
+
+This is the concrete inventory of what is public today.
+
+| | Artifact | What | Link |
+|---|---|---|---|
+| 🌐 | **SkillHub** | the current 114,190-skill catalog + the two models, hosted as an API — no install | [evermind.ai/skillhub](https://evermind.ai/skillhub) |
+| 📚 | **Corpus** *(demo)* | the downloadable 1,000-skill sample — `skills.parquet` + `attachments.tar.zst` + dataset card; the full catalog is served by SkillHub | [🤗 demo-1k](https://huggingface.co/datasets/EverMind-AI/skillcorpus-demo-1k) |
+| 🔡 | **Retrieval models** | a bi-encoder and a reranker, fine-tuned from `Qwen3-Embedding-0.6B` and `Qwen3-Reranker-0.6B` | [🤗 bi-encoder](https://huggingface.co/EverMind-AI/skillcorpus-embedding-0.6b) · [reranker](https://huggingface.co/EverMind-AI/skillcorpus-reranker-0.6b) |
+| 🛠️ | **Code** | this repo — the pipeline that builds the corpus and trains the two models (`aggregate` · `curate` · `match` · `evaluate` · `export`) | [GitHub](https://github.com/EverMind-AI/SkillCorpus) |
+| 🔌 | **Plugins** | packaged host adapters for OpenClaw · Hermes · WorkBuddy · Raven, plus DeepSeek Harness and an HTTP adapter | [`skillcorpus_plugin/`](skillcorpus_plugin) |
+
+*Open source today: the code, 1,000-skill demo corpus, and retrieval models. The hosted SkillHub
+service is closed, and the full hosted catalog is not yet published as a downloadable dataset.*
+
+<div align="center">
+<img src="docs/assets/taxonomy.png" alt="16-class distribution over the 96,401 active skills" width="58%">
+</div>
+
+The 96,401-skill snapshot measured in the paper, organised by a 16-class taxonomy and three quality facets
+(utility / robustness / safety), with 1024-dim retrieval embeddings. Column contract:
+[`docs/corpus-schema.md`](docs/corpus-schema.md).
 
 ## News
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 </table>
 
 <p align="center">
+  <a href="https://arxiv.org/abs/2607.15557"><img src="https://img.shields.io/badge/arXiv-2607.15557-b31b1b?labelColor=gray&style=for-the-badge" alt="Paper"></a>
   <a href="https://evermind.ai/skillhub"><img src="https://img.shields.io/badge/SkillHub-live-2ea44f?labelColor=gray&style=for-the-badge" alt="SkillHub"></a>
   <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge&logo=huggingface&logoColor=white" alt="Hugging Face"></a>
-  <a href="https://arxiv.org/abs/2607.15557"><img src="https://img.shields.io/badge/arXiv-2607.15557-b31b1b?labelColor=gray&style=for-the-badge" alt="Paper"></a>
 </p>
 
 <p align="center"><strong>English</strong> · <a href="README.zh-CN.md">简体中文</a></p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,6 +36,8 @@ SkillCorpus 是 EverMind 将公开仓库中散落的 `SKILL.md` 文件转化为�
 
 https://github.com/user-attachments/assets/4d9a3241-df13-4b20-9798-fb7920069995
 
+<br>
+
 ## 让 agent 每一轮都更强
 
 在 agent 作答时，真正的区别是一层检索：SkillHub 根据当前任务选出经过审核的过程性知识，
@@ -67,6 +69,8 @@ https://github.com/user-attachments/assets/4d9a3241-df13-4b20-9798-fb7920069995
 结果不是换了一个 agent，而是让同一个 agent 在真正需要时获得更贴合任务的过程性知识——不需要用户
 记技能名字，也不需要自己接工具调用。
 
+<br>
+
 ## 效果
 
 同一 harness、同一 backbone，通过率从「无技能」到「接入 SkillCorpus」的变化
@@ -82,6 +86,8 @@ https://github.com/user-attachments/assets/4d9a3241-df13-4b20-9798-fb7920069995
 
 任务越依赖模型本身不具备的过程性知识，收益越大（SkillsBench）；模型本来就能做的开放式
 经济类任务收益最小（GDPVal）。
+
+<br>
 
 ## SkillHub 集成
 
@@ -107,6 +113,8 @@ Raven 插件已经可以安装，但要等 Raven 上游合并 `context_segments`
 每轮的开销、以及哪些数据会离开你的机器——都在
 **[`skillcorpus_plugin/`](skillcorpus_plugin)**。
 
+<br>
+
 ## 公开产物
 
 下面这张表列出目前真正公开的产物。
@@ -127,6 +135,8 @@ Raven 插件已经可以安装，但要等 Raven 上游合并 `context_segments`
 
 论文所评测的 96,401 条快照，按 16 类体系和三个质量维度（utility / robustness / safety）组织，并带 1024 维
 检索向量。字段约定见 [`docs/corpus-schema.md`](docs/corpus-schema.md)。
+
+<br>
 
 ## 直接调 API
 
@@ -171,6 +181,8 @@ task: extract tables from a scanned PDF invoice
 
 端点、响应信封、状态码和限速见 [`docs/integrations.md`](docs/integrations.md)。
 
+<br>
+
 ## 自建模型服务
 
 若不想依赖托管端点，可自己跑 selection。语料和两个检索模型都已发布：加载数据、部署两个
@@ -203,6 +215,8 @@ EMBEDDING_MODEL=<embedding 检查点目录> RERANKER_MODEL=<reranker 检查点�
 - 它同时也是 producer 去重所用的 embedding 端点，把 `embedding.provider` 配成 `skillrouter_remote`，即可用它来[构建自己的语料](#build-your-own)。
 
 想策展**自己的**源，见 [构建自己的语料](#build-your-own)。
+
+<br>
 
 ## 工作原理
 
@@ -239,6 +253,8 @@ export.corpus`）。当没有可用的模型端点时，LLM 分类与质量打�
 
 <a name="build-your-own"></a>
 
+<br>
+
 ## 构建自己的语料
 
 仅当你想策展**自己的**源时才需要这一节。它需要一个 LLM 端点做分类与质量打分，以及一个
@@ -264,6 +280,8 @@ pip install -e ".[dev]"
 python -m pytest skillcorpus/tests -p no:cacheprovider --import-mode=importlib
 ```
 
+<br>
+
 ## 路线图
 
 <!-- TODO(@team)：这是按已知缺口列的初版，请按实际计划修改。 -->
@@ -276,6 +294,8 @@ python -m pytest skillcorpus/tests -p no:cacheprovider --import-mode=importlib
 - [x] 两个检索模型的部署脚本（自建 `match/`）
 - [x] 把 skill 库 + 检索框架打包成插件，供 WorkBuddy · Hermes · OpenClaw · DeepSeek Harness 使用
 - [ ] Raven 插件——已打包，等上游 `context_segments` 插槽
+
+<br>
 
 ## EverMind 生态系统
 
@@ -325,6 +345,8 @@ EverMind 是一个面向长期记忆、自我演进 agent、AI 原生界面和�
 
 这些仓库共同构成 EverMind 从研究到运行时的技术栈：新的记忆方法、可复用算法、基准证据与实用的 agent 集成。
 
+<br>
+
 ## 引用
 
 ```bibtex
@@ -337,6 +359,8 @@ EverMind 是一个面向长期记忆、自我演进 agent、AI 原生界面和�
   url           = {https://arxiv.org/abs/2607.15557}
 }
 ```
+
+<br>
 
 ## 许可
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,42 +6,36 @@
 <tr><td><img src="https://github.com/user-attachments/assets/2ef7e877-275d-4115-8ddf-f9b49de8ff5d" alt="SkillCorpus 横幅" width="100%"></td></tr>
 </table>
 
-[![Paper](https://img.shields.io/badge/arXiv-2607.15557-b31b1b.svg)](https://arxiv.org/abs/2607.15557)
-[![SkillHub](https://img.shields.io/badge/SkillHub-live-2ea44f.svg)](https://evermind.ai/skillhub)
-[![License](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](#许可)
-![Python](https://img.shields.io/badge/python-3.10+-blue.svg)
+<p align="center">
+  <a href="https://github.com/EverMind-AI/SkillCorpus"><img src="https://img.shields.io/badge/SkillCorpus-EverMind_Open--Source-000000?labelColor=gray&style=for-the-badge&logo=github&logoColor=white" alt="SkillCorpus"></a>
+  <a href="https://evermind.ai/skillhub"><img src="https://img.shields.io/badge/SkillHub-live-2ea44f?labelColor=gray&style=for-the-badge" alt="SkillHub"></a>
+  <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge&logo=huggingface&logoColor=white" alt="Hugging Face"></a>
+  <a href="https://arxiv.org/abs/2607.15557"><img src="https://img.shields.io/badge/arXiv-2607.15557-b31b1b?labelColor=gray&style=for-the-badge" alt="Paper"></a>
+</p>
 
-[English](README.md) | **简体中文**
+<p align="center"><a href="README.md">English</a> · <a href="https://evermind.ai/skillhub">SkillHub</a> · <strong>简体中文</strong></p>
 
 </div>
 
+<br>
+
+## SkillCorpus 能给你什么
+
 SkillCorpus 是 EverMind 将公开仓库中散落的 `SKILL.md` 文件转化为可靠 agent 上下文的开源流水线：
-它聚合源仓库，执行安全与许可门禁，评估质量，并在 agent 作答前匹配与任务相关的技能。公开的
-1,000 条 demo 语料、三个 agent benchmark 和线上的 [SkillHub](https://evermind.ai/skillhub)
-展示了结果；想构建、修改或自行部署这套开源核心时，再 clone 本仓库。
+它聚合源仓库，执行安全与许可门禁，评估质量，并在 agent 作答前匹配与任务相关的技能。
+
+你可以直接使用线上的 [SkillHub](https://evermind.ai/skillhub)，不需要 clone 本仓库。只有当你想拥有
+这套能力的开源底座时，才需要 clone SkillCorpus：
+
+- **构建自己的技能层** —— 把流水线指向自己的 source registry，使用策展、安全和许可门禁，再为自己的
+  agent 导出语料。
+- **修改它的行为** —— 修改分类体系、质量与去重规则、检索配方、导出字段、评测套件或宿主插件。
+- **掌控部署方式** —— 自己部署已发布的检索模型，把自己的 agent 接进来，而不是依赖托管的 SkillHub API。
+
+核心代码采用 Apache-2.0 许可（`match/` 和 `evaluate/` 两个工具包为 MIT）；每个技能保留其上游许可。
+公开的 1,000 条 demo 语料、三个 agent benchmark 和线上的 SkillHub 展示了结果。
 
 https://github.com/user-attachments/assets/4d9a3241-df13-4b20-9798-fb7920069995
-
-<details>
-  <summary><kbd>目录</kbd></summary>
-
-<br>
-
-- [让 agent 每一轮都更强](#让-agent-每一轮都更强)
-- [效果](#效果)
-- [公开产物](#公开产物)
-- [SkillCorpus 能给你什么](#skillcorpus-能给你什么)
-- [面向你的 agent 宿主的 SkillHub](#面向你的-agent-宿主的-skillhub)
-- [动态](#动态)
-- [其余用法](#其余用法)
-- [工作原理](#工作原理)
-- [构建自己的语料](#构建自己的语料)
-- [路线图](#路线图)
-- [EverMind 生态系统](#evermind-生态系统)
-
-<br>
-
-</details>
 
 ## 让 agent 每一轮都更强
 
@@ -110,19 +104,6 @@ https://github.com/user-attachments/assets/4d9a3241-df13-4b20-9798-fb7920069995
 
 论文所评测的 96,401 条快照，按 16 类体系和三个质量维度（utility / robustness / safety）组织，并带 1024 维
 检索向量。字段约定见 [`docs/corpus-schema.md`](docs/corpus-schema.md)。
-
-## SkillCorpus 能给你什么
-
-你可以直接使用线上的 [SkillHub](https://evermind.ai/skillhub)，不需要 clone 本仓库。只有当你想拥有
-这套能力的开源底座时，才需要 clone SkillCorpus：
-
-- **构建自己的技能层** —— 把流水线指向自己的 source registry，使用策展、安全和许可门禁，再为自己的
-  agent 导出语料。
-- **修改它的行为** —— 修改分类体系、质量与去重规则、检索配方、导出字段、评测套件或宿主插件。
-- **掌控部署方式** —— 自己部署已发布的检索模型，把自己的 agent 接进来，而不是依赖托管的 SkillHub API。
-
-核心代码采用 Apache-2.0 许可（`match/` 和 `evaluate/` 两个工具包为 MIT）；每个技能保留其上游许可。
-可以从[构建自己的语料](#构建自己的语料)开始，也可以先用 SkillHub 体验结果，再决定要不要修改底层机制。
 
 ## 面向你的 agent 宿主的 SkillHub
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,11 +7,10 @@
 </table>
 
 <p align="center">
-  <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge&logo=huggingface&logoColor=white" alt="Hugging Face"></a>
-  <a href="https://evermind.ai/skillhub"><img src="https://img.shields.io/badge/SkillHub-live-2ea44f?labelColor=gray&style=for-the-badge" alt="SkillHub"></a>
-  <a href="https://discord.gg/gYep5nQRZJ"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FgYep5nQRZJ%3Fwith_counts%3Dtrue&query=%24.approximate_presence_count&suffix=%20online&label=Discord&color=404EED&labelColor=gray&style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
-  <a href="https://github.com/EverMind-AI/EverOS/discussions/67"><img src="https://img.shields.io/badge/WeCom-EverMind_社区-07C160?labelColor=gray&style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
   <a href="https://arxiv.org/abs/2607.15557"><img src="https://img.shields.io/badge/arXiv-2607.15557-b31b1b?labelColor=gray&style=for-the-badge" alt="Paper"></a>
+  <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge&logo=huggingface&logoColor=white" alt="Hugging Face"></a>
+  <a href="https://discord.gg/gYep5nQRZJ"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FgYep5nQRZJ%3Fwith_counts%3Dtrue&query=%24.approximate_presence_count&suffix=%20online&label=Discord&color=404EED&labelColor=gray&style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://github.com/EverMind-AI/EverOS/discussions/67"><img src="https://img.shields.io/badge/WeCom-EverMind_%E7%A4%BE%E5%8C%BA-07C160?labelColor=gray&style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
 </p>
 
 <p align="center"><a href="README.md">English</a> · <strong>简体中文</strong></p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,9 +7,11 @@
 </table>
 
 <p align="center">
-  <a href="https://arxiv.org/abs/2607.15557"><img src="https://img.shields.io/badge/arXiv-2607.15557-b31b1b?labelColor=gray&style=for-the-badge" alt="Paper"></a>
-  <a href="https://evermind.ai/skillhub"><img src="https://img.shields.io/badge/SkillHub-live-2ea44f?labelColor=gray&style=for-the-badge" alt="SkillHub"></a>
   <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge&logo=huggingface&logoColor=white" alt="Hugging Face"></a>
+  <a href="https://evermind.ai/skillhub"><img src="https://img.shields.io/badge/SkillHub-live-2ea44f?labelColor=gray&style=for-the-badge" alt="SkillHub"></a>
+  <a href="https://discord.gg/gYep5nQRZJ"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FgYep5nQRZJ%3Fwith_counts%3Dtrue&query=%24.approximate_presence_count&suffix=%20online&label=Discord&color=404EED&labelColor=gray&style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://github.com/EverMind-AI/EverOS/discussions/67"><img src="https://img.shields.io/badge/WeCom-EverMind_社区-07C160?labelColor=gray&style=for-the-badge&logo=wechat&logoColor=white" alt="WeChat"></a>
+  <a href="https://arxiv.org/abs/2607.15557"><img src="https://img.shields.io/badge/arXiv-2607.15557-b31b1b?labelColor=gray&style=for-the-badge" alt="Paper"></a>
 </p>
 
 <p align="center"><a href="README.md">English</a> · <strong>简体中文</strong></p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,9 +7,9 @@
 </table>
 
 <p align="center">
+  <a href="https://arxiv.org/abs/2607.15557"><img src="https://img.shields.io/badge/arXiv-2607.15557-b31b1b?labelColor=gray&style=for-the-badge" alt="Paper"></a>
   <a href="https://evermind.ai/skillhub"><img src="https://img.shields.io/badge/SkillHub-live-2ea44f?labelColor=gray&style=for-the-badge" alt="SkillHub"></a>
   <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge&logo=huggingface&logoColor=white" alt="Hugging Face"></a>
-  <a href="https://arxiv.org/abs/2607.15557"><img src="https://img.shields.io/badge/arXiv-2607.15557-b31b1b?labelColor=gray&style=for-the-badge" alt="Paper"></a>
 </p>
 
 <p align="center"><a href="README.md">English</a> · <strong>简体中文</strong></p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -128,17 +128,7 @@ Raven 插件已经可以安装，但要等 Raven 上游合并 `context_segments`
 论文所评测的 96,401 条快照，按 16 类体系和三个质量维度（utility / robustness / safety）组织，并带 1024 维
 检索向量。字段约定见 [`docs/corpus-schema.md`](docs/corpus-schema.md)。
 
-## 动态
-
-- **2026-08-19** —— **SkillCorpus Plugins** 发布：在 WorkBuddy、Hermes、OpenClaw、DeepSeek Harness 里逐轮检索技能。
-- **2026-08-12** —— 检索模型（bi-encoder + reranker）与 1,000 条 demo 语料上 [🤗 HuggingFace](https://huggingface.co/EverMind-AI)。
-- **2026-08-06** —— 论文 v5 上 [arXiv](https://arxiv.org/abs/2607.15557)。
-
-## 其余用法
-
-上面的插件覆盖了大多数人。如果你想自己调服务，或者把整套跑在自己的机器上：
-
-### 直接调 API
+## 直接调 API
 
 [SkillHub](https://evermind.ai/skillhub) 把语料分三级提供：发现（元数据）、读正文
 （`skill_md`）、下载（含 `scripts/` 的 zip）。大多数技能是纯指令，读正文这一级通常已足够。
@@ -181,7 +171,7 @@ task: extract tables from a scanned PDF invoice
 
 端点、响应信封、状态码和限速见 [`docs/integrations.md`](docs/integrations.md)。
 
-### 自建模型服务
+## 自建模型服务
 
 若不想依赖托管端点，可自己跑 selection。语料和两个检索模型都已发布：加载数据、部署两个
 模型，自己做 encode → top-k → rerank。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -83,30 +83,9 @@ https://github.com/user-attachments/assets/4d9a3241-df13-4b20-9798-fb7920069995
 任务越依赖模型本身不具备的过程性知识，收益越大（SkillsBench）；模型本来就能做的开放式
 经济类任务收益最小（GDPVal）。
 
-## 公开产物
+## SkillHub 集成
 
-下面这张表列出目前真正公开的产物。
-
-| | 产物 | 内容 | 链接 |
-|---|---|---|---|
-| 🌐 | **SkillHub** | 当前 114,190 条在线目录 + 那两个模型的托管 API，无需安装 | [evermind.ai/skillhub](https://evermind.ai/skillhub) |
-| 📚 | **语料** *(demo)* | 可下载的 1,000 条样本 —— `skills.parquet` + `attachments.tar.zst` + dataset card；完整目录由 SkillHub 提供服务 | [🤗 demo-1k](https://huggingface.co/datasets/EverMind-AI/skillcorpus-demo-1k) |
-| 🔡 | **检索模型** | 从 `Qwen3-Embedding-0.6B` 和 `Qwen3-Reranker-0.6B` 微调出的 bi-encoder 与 reranker | [🤗 bi-encoder](https://huggingface.co/EverMind-AI/skillcorpus-embedding-0.6b) · [reranker](https://huggingface.co/EverMind-AI/skillcorpus-reranker-0.6b) |
-| 🛠️ | **代码** | 本仓库 —— 构建语料、训练那两个模型的流水线（`aggregate` · `curate` · `match` · `evaluate` · `export`） | [GitHub](https://github.com/EverMind-AI/SkillCorpus) |
-| 🔌 | **插件** | 为 OpenClaw · Hermes · WorkBuddy · Raven 提供宿主适配器，另有 DeepSeek Harness 与 HTTP adapter | [`skillcorpus_plugin/`](skillcorpus_plugin) |
-
-*目前开源：代码、1,000 条 demo 语料和检索模型。托管的 SkillHub 服务不开源，完整在线目录也尚未作为可下载数据集发布。*
-
-<div align="center">
-<img src="docs/assets/taxonomy.png" alt="96,401 个有效技能的 16 类分布" width="58%">
-</div>
-
-论文所评测的 96,401 条快照，按 16 类体系和三个质量维度（utility / robustness / safety）组织，并带 1024 维
-检索向量。字段约定见 [`docs/corpus-schema.md`](docs/corpus-schema.md)。
-
-## 面向你的 agent 宿主的 SkillHub
-
-SkillHub 已为下面五个宿主提供逐轮技能检索。点击对应图标，直接查看该宿主的插件指南：
+SkillHub 已为下面五个 agent 平台提供逐轮技能检索。点击对应平台，直接查看插件指南：
 
 <table width="100%">
 <tr>
@@ -127,6 +106,27 @@ Raven 插件已经可以安装，但要等 Raven 上游合并 `context_segments`
 把上面这句粘给你的 agent，它会自己装好。各宿主的具体配置、你真正会碰的五个配置项、
 每轮的开销、以及哪些数据会离开你的机器——都在
 **[`skillcorpus_plugin/`](skillcorpus_plugin)**。
+
+## 公开产物
+
+下面这张表列出目前真正公开的产物。
+
+| | 产物 | 内容 | 链接 |
+|---|---|---|---|
+| 🌐 | **SkillHub** | 当前 114,190 条在线目录 + 那两个模型的托管 API，无需安装 | [evermind.ai/skillhub](https://evermind.ai/skillhub) |
+| 📚 | **语料** *(demo)* | 可下载的 1,000 条样本 —— `skills.parquet` + `attachments.tar.zst` + dataset card；完整目录由 SkillHub 提供服务 | [🤗 demo-1k](https://huggingface.co/datasets/EverMind-AI/skillcorpus-demo-1k) |
+| 🔡 | **检索模型** | 从 `Qwen3-Embedding-0.6B` 和 `Qwen3-Reranker-0.6B` 微调出的 bi-encoder 与 reranker | [🤗 bi-encoder](https://huggingface.co/EverMind-AI/skillcorpus-embedding-0.6b) · [reranker](https://huggingface.co/EverMind-AI/skillcorpus-reranker-0.6b) |
+| 🛠️ | **代码** | 本仓库 —— 构建语料、训练那两个模型的流水线（`aggregate` · `curate` · `match` · `evaluate` · `export`） | [GitHub](https://github.com/EverMind-AI/SkillCorpus) |
+| 🔌 | **插件** | 为 OpenClaw · Hermes · WorkBuddy · Raven 提供宿主适配器，另有 DeepSeek Harness 与 HTTP adapter | [`skillcorpus_plugin/`](skillcorpus_plugin) |
+
+*目前开源：代码、1,000 条 demo 语料和检索模型。托管的 SkillHub 服务不开源，完整在线目录也尚未作为可下载数据集发布。*
+
+<div align="center">
+<img src="docs/assets/taxonomy.png" alt="96,401 个有效技能的 16 类分布" width="58%">
+</div>
+
+论文所评测的 96,401 条快照，按 16 类体系和三个质量维度（utility / robustness / safety）组织，并带 1024 维
+检索向量。字段约定见 [`docs/corpus-schema.md`](docs/corpus-schema.md)。
 
 ## 动态
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,13 +7,12 @@
 </table>
 
 <p align="center">
-  <a href="https://github.com/EverMind-AI/SkillCorpus"><img src="https://img.shields.io/badge/SkillCorpus-EverMind_Open--Source-000000?labelColor=gray&style=for-the-badge&logo=github&logoColor=white" alt="SkillCorpus"></a>
   <a href="https://evermind.ai/skillhub"><img src="https://img.shields.io/badge/SkillHub-live-2ea44f?labelColor=gray&style=for-the-badge" alt="SkillHub"></a>
   <a href="https://huggingface.co/EverMind-AI"><img src="https://img.shields.io/badge/HuggingFace-EverMind-F5C842?labelColor=gray&style=for-the-badge&logo=huggingface&logoColor=white" alt="Hugging Face"></a>
   <a href="https://arxiv.org/abs/2607.15557"><img src="https://img.shields.io/badge/arXiv-2607.15557-b31b1b?labelColor=gray&style=for-the-badge" alt="Paper"></a>
 </p>
 
-<p align="center"><a href="README.md">English</a> · <a href="https://evermind.ai/skillhub">SkillHub</a> · <strong>简体中文</strong></p>
+<p align="center"><a href="README.md">English</a> · <strong>简体中文</strong></p>
 
 </div>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -287,29 +287,6 @@ python -m pytest skillcorpus/tests -p no:cacheprovider --import-mode=importlib
 - [x] 把 skill 库 + 检索框架打包成插件，供 WorkBuddy · Hermes · OpenClaw · DeepSeek Harness 使用
 - [ ] Raven 插件——已打包，等上游 `context_segments` 插槽
 
-## 引用
-
-```bibtex
-@article{wang2026skillcorpus,
-  title         = {SkillCorpus: Consolidating and Evaluating the Open Skill Ecosystem for Real-World LLM Agents},
-  author        = {Wang, Yanze and Yao, Pengfei and Sun, Tianyi and Hu, Chuanrui and Xiao, Yan and Luo, Xiaotian and Han, Yunyun and Chen, Yifan and Sun, Jun and Deng, Yafeng},
-  year          = {2026},
-  eprint        = {2607.15557},
-  archivePrefix = {arXiv},
-  url           = {https://arxiv.org/abs/2607.15557}
-}
-```
-
-## 许可
-
-- **代码** —— Apache-2.0（`match/` 和 `evaluate/` 两个工具包各自为 MIT，见其目录下的 `LICENSE`）。
-- **语料** —— 每个技能保留其**上游原始许可**；只收录 GREEN（MIT / Apache-2.0 / BSD / ISC / …）
-  许可的技能，不做任何重新授权。每行都带 `source`、`source_url`、`license`，下游使用须遵循
-  各技能自身的条款。
-
-完整的 GREEN/RED/YELLOW 策略、许可数据流与 opt-out 通道见
-[`docs/licence-and-governance.md`](docs/licence-and-governance.md)。
-
 ## EverMind 生态系统
 
 EverMind 是一个面向长期记忆、自我演进 agent、AI 原生界面和记忆评估的开源生态系统。
@@ -357,3 +334,26 @@ EverMind 是一个面向长期记忆、自我演进 agent、AI 原生界面和�
 </table>
 
 这些仓库共同构成 EverMind 从研究到运行时的技术栈：新的记忆方法、可复用算法、基准证据与实用的 agent 集成。
+
+## 引用
+
+```bibtex
+@article{wang2026skillcorpus,
+  title         = {SkillCorpus: Consolidating and Evaluating the Open Skill Ecosystem for Real-World LLM Agents},
+  author        = {Wang, Yanze and Yao, Pengfei and Sun, Tianyi and Hu, Chuanrui and Xiao, Yan and Luo, Xiaotian and Han, Yunyun and Chen, Yifan and Sun, Jun and Deng, Yafeng},
+  year          = {2026},
+  eprint        = {2607.15557},
+  archivePrefix = {arXiv},
+  url           = {https://arxiv.org/abs/2607.15557}
+}
+```
+
+## 许可
+
+- **代码** —— Apache-2.0（`match/` 和 `evaluate/` 两个工具包各自为 MIT，见其目录下的 `LICENSE`）。
+- **语料** —— 每个技能保留其**上游原始许可**；只收录 GREEN（MIT / Apache-2.0 / BSD / ISC / …）
+  许可的技能，不做任何重新授权。每行都带 `source`、`source_url`、`license`，下游使用须遵循
+  各技能自身的条款。
+
+完整的 GREEN/RED/YELLOW 策略、许可数据流与 opt-out 通道见
+[`docs/licence-and-governance.md`](docs/licence-and-governance.md)。


### PR DESCRIPTION
## Summary

- replace the compact top badges with larger EverMind-style badges
- remove the table of contents
- move the SkillCorpus value proposition directly below the banner
- keep results and public artifacts before the SkillHub plugin section
- apply the same structure to the English and Chinese READMEs

## Validation

- git diff --check
- verified the TOC markers are removed
- verified both value and plugin sections are present