### PR TITLE
Feat/pathguard placeholder resolution

### DIFF
--- a/skillcorpus_plugin/CHANGELOG.md
+++ b/skillcorpus_plugin/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 - **Default multi-source retrieval** now searches local skills, EverMind when configured, ClawHub, and skillhub.cn concurrently. Each source contributes at most two candidates; suspicious or malicious entries are rejected, bundles are safely cached, source failures are isolated, and the final gate still selects 0–2 skills. ClawHub and skillhub.cn can each be disabled with an empty endpoint.
 
+- **PathGuard placeholder resolution** — both engines resolve
+  `{{SKILL_DIR}}`, `{{SKILL_DIR:<name>}}`, `{{AGENT_STATE_DIR}}`,
+  `{{HOME}}` and `{{OUTPUT_DIR}}` in skill bodies to real host paths, for
+  corpora produced by a PathGuard pass. Gated behind `resolve_placeholders`
+  (Python) / `resolvePlaceholders` (TypeScript), **off by default** so
+  arbitrary third-party skills never get a machine-agnostic placeholder
+  expanded onto this host's filesystem; each host plugin exposes the switch
+  and supplies its own `output_dir` / `home_dir` / `state_dir` (OpenClaw and
+  WorkBuddy take the per-turn workspace from the hook payload).
+
 - **A fifth host: WorkBuddy** ([`plugin-workbuddy/`](plugin-workbuddy)), where
   the seam is a process — a `UserPromptSubmit` hook spawned per turn, reading
   the turn from stdin and answering with `additionalContext` on stdout. Ships

--- a/skillcorpus_plugin/engine-python/skillsearch/config.py
+++ b/skillcorpus_plugin/engine-python/skillsearch/config.py
@@ -180,6 +180,13 @@ class SearchConfig:
     paths. Requires the host and the skills to share a filesystem; turn it
     off when serving retrieval over HTTP."""
 
+    resolve_placeholders: bool = False
+    """Expand PathGuard placeholders (``{{SKILL_DIR}}``, ``{{HOME}}`` …) in
+    skill bodies to real host paths. Off by default: it maps a
+    machine-agnostic placeholder onto this host's filesystem, so it should
+    only be turned on for a corpus that a trusted PathGuard pass produced —
+    never for arbitrary third-party skills."""
+
     heading: str = "# Skills"
 
     # ── Host-provided, not user-facing ───────────────────────────────

--- a/skillcorpus_plugin/engine-python/skillsearch/config.py
+++ b/skillcorpus_plugin/engine-python/skillsearch/config.py
@@ -187,6 +187,19 @@ class SearchConfig:
     cache_dir: str = ""
     """Where downloaded bundles are extracted. Defaults under ``workspace``."""
 
+    output_dir: str = ""
+    """The agent's writable output directory, for ``{{OUTPUT_DIR}}``.
+    Empty resolves to ``workspace`` at substitution time."""
+
+    home_dir: str = ""
+    """The agent's home directory, for ``{{HOME}}``. Empty falls back to
+    ``output_dir`` (then ``workspace``) at substitution time."""
+
+    state_dir: str = ""
+    """The agent's own config/state root, for ``{{AGENT_STATE_DIR}}``
+    (``~/.openclaw``, ``~/.hermes`` …). Empty means this agent has no such
+    concept, and the placeholder falls back to ``output_dir``."""
+
     def gate_enabled(self) -> bool:
         """Whether to build the gate, resolving the ``None`` default."""
         has_remote = bool(self.hub_endpoint or self.clawhub_endpoint or self.skillhub_cn_endpoint)

--- a/skillcorpus_plugin/engine-python/skillsearch/engine.py
+++ b/skillcorpus_plugin/engine-python/skillsearch/engine.py
@@ -507,15 +507,19 @@ class SkillSearch:
     def _resolve_placeholders(self, hits: list[RouterHit]) -> list[RouterHit]:
         """Fill PathGuard placeholders ({{SKILL_DIR}}, {{HOME}}, …) per agent.
 
-        Unlike :meth:`_resolve_local_refs` / :meth:`_hydrate_refs` this never
-        touches the filesystem and is not gated by ``resolve_refs``: a
-        placeholder already names its target, and only the host knows it. It
-        runs last, once every surviving hit has its ``skill_dir`` settled, so
-        both local and remote bodies pass through the same pass.
+        Gated by ``resolve_placeholders`` (off by default): a placeholder maps
+        machine-agnostic text onto this host's real filesystem, so it must only
+        run for a corpus a trusted PathGuard pass produced, not for arbitrary
+        third-party skills. Unlike :meth:`_resolve_local_refs` /
+        :meth:`_hydrate_refs` this never touches the filesystem; it runs last,
+        once every surviving hit has its ``skill_dir`` settled.
         """
+        cfg = self._cfg
+        if not cfg.resolve_placeholders:
+            return hits
+
         from skillsearch.refs import resolve_placeholders
 
-        cfg = self._cfg
         output_dir = cfg.output_dir or cfg.workspace
         out: list[RouterHit] = []
         for hit in hits:

--- a/skillcorpus_plugin/engine-python/skillsearch/engine.py
+++ b/skillcorpus_plugin/engine-python/skillsearch/engine.py
@@ -357,6 +357,7 @@ class SkillSearch:
         # so it waits until the gate has decided what is actually going in.
         if cfg.resolve_refs:
             hits = await self._hydrate_refs(hits)
+        hits = self._resolve_placeholders(hits)
         return hits
 
     def _resolve_local_refs(self, hits: list[RouterHit]) -> list[RouterHit]:
@@ -502,6 +503,40 @@ class SkillSearch:
             return hit
 
         return list(await asyncio.gather(*(_one(h) for h in hits)))
+
+    def _resolve_placeholders(self, hits: list[RouterHit]) -> list[RouterHit]:
+        """Fill PathGuard placeholders ({{SKILL_DIR}}, {{HOME}}, …) per agent.
+
+        Unlike :meth:`_resolve_local_refs` / :meth:`_hydrate_refs` this never
+        touches the filesystem and is not gated by ``resolve_refs``: a
+        placeholder already names its target, and only the host knows it. It
+        runs last, once every surviving hit has its ``skill_dir`` settled, so
+        both local and remote bodies pass through the same pass.
+        """
+        from skillsearch.refs import resolve_placeholders
+
+        cfg = self._cfg
+        output_dir = cfg.output_dir or cfg.workspace
+        out: list[RouterHit] = []
+        for hit in hits:
+            content = hit.content or ""
+            if not content or "{{" not in content:
+                out.append(hit)
+                continue
+            try:
+                resolved = resolve_placeholders(
+                    content,
+                    (hit.meta or {}).get("skill_dir"),
+                    state_dir=cfg.state_dir or None,
+                    home_dir=cfg.home_dir or None,
+                    output_dir=output_dir,
+                )
+            except Exception as e:
+                log.debug("skillsearch: could not resolve placeholders for %s (%s)", hit.name, e)
+                out.append(hit)
+                continue
+            out.append(replace(hit, content=resolved) if resolved != content else hit)
+        return out
 
     def render(self, hits: list[RouterHit]) -> str:
         """Render selected hits into the block. Public so an adapter can

--- a/skillcorpus_plugin/engine-python/skillsearch/engine.py
+++ b/skillcorpus_plugin/engine-python/skillsearch/engine.py
@@ -524,13 +524,16 @@ class SkillSearch:
         out: list[RouterHit] = []
         for hit in hits:
             content = hit.content or ""
-            if not content or "{{" not in content:
+            meta = hit.meta or {}
+            source = str(meta.get("source") or "")
+            trusted = source in {"local", "builtin", "hub"} or meta.get("pathguard_processed") is True
+            if not trusted or not content or "{{" not in content:
                 out.append(hit)
                 continue
             try:
                 resolved = resolve_placeholders(
                     content,
-                    (hit.meta or {}).get("skill_dir"),
+                    meta.get("skill_dir"),
                     state_dir=cfg.state_dir or None,
                     home_dir=cfg.home_dir or None,
                     output_dir=output_dir,

--- a/skillcorpus_plugin/engine-python/skillsearch/refs.py
+++ b/skillcorpus_plugin/engine-python/skillsearch/refs.py
@@ -140,7 +140,11 @@ def resolve_placeholders(
     def _sub(m: re.Match[str]) -> str:
         name, arg = m.group(1), m.group(2)
         if name == "SKILL_DIR":  # {{SKILL_DIR:<name>}} — arg is a safe slug
-            return str(Path(sd).parent / arg) if sd and arg else m.group(0)
+            return (
+                str(Path(sd).parent / arg)
+                if sd and arg and arg not in {".", ".."}
+                else m.group(0)
+            )
         if name == "AGENT_STATE_DIR":
             return state_dir or output_dir or m.group(0)
         if name == "HOME":

--- a/skillcorpus_plugin/engine-python/skillsearch/refs.py
+++ b/skillcorpus_plugin/engine-python/skillsearch/refs.py
@@ -140,11 +140,7 @@ def resolve_placeholders(
     def _sub(m: re.Match[str]) -> str:
         name, arg = m.group(1), m.group(2)
         if name == "SKILL_DIR":  # {{SKILL_DIR:<name>}} — arg is a safe slug
-            return (
-                str(Path(sd).parent / arg)
-                if sd and arg and arg not in {".", ".."}
-                else m.group(0)
-            )
+            return str(Path(sd).parent / arg) if sd and arg and arg not in {".", ".."} else m.group(0)
         if name == "AGENT_STATE_DIR":
             return state_dir or output_dir or m.group(0)
         if name == "HOME":

--- a/skillcorpus_plugin/engine-python/skillsearch/refs.py
+++ b/skillcorpus_plugin/engine-python/skillsearch/refs.py
@@ -92,7 +92,7 @@ def resolve_refs(body: str, skill_dir: Path | str | None) -> tuple[str, bool]:
     return body, any_resolved
 
 
-_PLACEHOLDER_RE = re.compile(r"\{\{([A-Z_]+)(?::([^}]+))?\}\}")
+_PLACEHOLDER_RE = re.compile(r"\{\{([A-Z_]+)(?::([A-Za-z0-9._-]+))?\}\}")
 
 
 def resolve_placeholders(
@@ -112,9 +112,9 @@ def resolve_placeholders(
     in per agent, next to :func:`resolve_refs`.
 
     - ``{{SKILL_DIR}}`` → this skill's bundle directory; ``{{SKILL_DIR:<n>}}``
-      → a sibling bundle under the same parent. Without a directory on disk
-      the prefix is stripped to a bare relative path, the same policy
-      ``resolve_refs`` applies to ``{baseDir}``.
+      → a sibling bundle under the same parent. ``<n>`` is restricted to a safe
+      slug (``[A-Za-z0-9._-]+``), so a traversal like ``../../x`` or an absolute
+      path does not match and stays literal.
     - ``{{AGENT_STATE_DIR}}`` → the agent's own config/state root, falling back
       to ``output_dir`` when this agent has none.
     - ``{{HOME}}`` → the agent's home, falling back to ``output_dir`` when unset.
@@ -129,18 +129,18 @@ def resolve_placeholders(
 
     sd = str(skill_dir) if skill_dir else None
 
-    # Bare {{SKILL_DIR}} and {{SKILL_DIR}}/… — the slash is folded in so a
-    # missing directory does not leave a leading "/scripts/x.py".
+    # Bare {{SKILL_DIR}} and {{SKILL_DIR}}/… — the slash is folded in so the
+    # directory is written once. Without a directory on disk the placeholder is
+    # left literal, not stripped: a bare `scripts/x.py` would tell the model the
+    # bundle is present when it never downloaded.
     if sd:
         body = body.replace("{{SKILL_DIR}}/", sd.rstrip("/") + "/")
         body = body.replace("{{SKILL_DIR}}", sd)
-    else:
-        body = body.replace("{{SKILL_DIR}}/", "").replace("{{SKILL_DIR}}", "")
 
     def _sub(m: re.Match[str]) -> str:
         name, arg = m.group(1), m.group(2)
-        if name == "SKILL_DIR":  # {{SKILL_DIR:<name>}}
-            return str(Path(sd).parent / arg) if sd else m.group(0)
+        if name == "SKILL_DIR":  # {{SKILL_DIR:<name>}} — arg is a safe slug
+            return str(Path(sd).parent / arg) if sd and arg else m.group(0)
         if name == "AGENT_STATE_DIR":
             return state_dir or output_dir or m.group(0)
         if name == "HOME":
@@ -152,4 +152,4 @@ def resolve_placeholders(
     return _PLACEHOLDER_RE.sub(_sub, body)
 
 
-__all__ = ["resolve_refs", "resolve_placeholders"]
+__all__ = ["resolve_placeholders", "resolve_refs"]

--- a/skillcorpus_plugin/engine-python/skillsearch/refs.py
+++ b/skillcorpus_plugin/engine-python/skillsearch/refs.py
@@ -92,4 +92,64 @@ def resolve_refs(body: str, skill_dir: Path | str | None) -> tuple[str, bool]:
     return body, any_resolved
 
 
-__all__ = ["resolve_refs"]
+_PLACEHOLDER_RE = re.compile(r"\{\{([A-Z_]+)(?::([^}]+))?\}\}")
+
+
+def resolve_placeholders(
+    body: str,
+    skill_dir: str | None,
+    *,
+    state_dir: str | None = None,
+    home_dir: str | None = None,
+    output_dir: str | None = None,
+) -> str:
+    """Replace PathGuard placeholders in a skill body with real paths.
+
+    ``{{SKILL_DIR}}`` / ``{{SKILL_DIR:<name>}}`` / ``{{AGENT_STATE_DIR}}`` /
+    ``{{HOME}}`` / ``{{OUTPUT_DIR}}`` are written by an offline pass over a
+    shared skill library (see ``skill_retire_and_classify/pathguard``) that
+    rewrites hardcoded paths to agent-agnostic placeholders. This fills them
+    in per agent, next to :func:`resolve_refs`.
+
+    - ``{{SKILL_DIR}}`` → this skill's bundle directory; ``{{SKILL_DIR:<n>}}``
+      → a sibling bundle under the same parent. Without a directory on disk
+      the prefix is stripped to a bare relative path, the same policy
+      ``resolve_refs`` applies to ``{baseDir}``.
+    - ``{{AGENT_STATE_DIR}}`` → the agent's own config/state root, falling back
+      to ``output_dir`` when this agent has none.
+    - ``{{HOME}}`` → the agent's home, falling back to ``output_dir`` when unset.
+    - ``{{OUTPUT_DIR}}`` → the agent's writable output directory.
+
+    Substitution is unconditional — unlike :func:`resolve_refs` it never checks
+    the filesystem, because a placeholder already carries its replacement target
+    and only the host knows it.
+    """
+    if not body or "{{" not in body:
+        return body
+
+    sd = str(skill_dir) if skill_dir else None
+
+    # Bare {{SKILL_DIR}} and {{SKILL_DIR}}/… — the slash is folded in so a
+    # missing directory does not leave a leading "/scripts/x.py".
+    if sd:
+        body = body.replace("{{SKILL_DIR}}/", sd.rstrip("/") + "/")
+        body = body.replace("{{SKILL_DIR}}", sd)
+    else:
+        body = body.replace("{{SKILL_DIR}}/", "").replace("{{SKILL_DIR}}", "")
+
+    def _sub(m: re.Match[str]) -> str:
+        name, arg = m.group(1), m.group(2)
+        if name == "SKILL_DIR":  # {{SKILL_DIR:<name>}}
+            return str(Path(sd).parent / arg) if sd else m.group(0)
+        if name == "AGENT_STATE_DIR":
+            return state_dir or output_dir or m.group(0)
+        if name == "HOME":
+            return home_dir or output_dir or m.group(0)
+        if name == "OUTPUT_DIR":
+            return output_dir or m.group(0)
+        return m.group(0)
+
+    return _PLACEHOLDER_RE.sub(_sub, body)
+
+
+__all__ = ["resolve_refs", "resolve_placeholders"]

--- a/skillcorpus_plugin/engine-python/tests/test_engine.py
+++ b/skillcorpus_plugin/engine-python/tests/test_engine.py
@@ -84,6 +84,26 @@ def test_exact_normalized_body_dedup_prefers_local_and_keeps_near_duplicates() -
     assert [hit.qualified_id for hit in result] == ["local/copy", "remote/near"]
 
 
+def test_placeholder_resolution_skips_untrusted_marketplaces(tmp_path: Path) -> None:
+    from skillsearch.types import RouterHit
+
+    search = SkillSearch(
+        SearchConfig(
+            skills_dir="absent",
+            workspace=str(tmp_path),
+            resolve_placeholders=True,
+            output_dir="/workspace",
+        )
+    )
+    untrusted = RouterHit("clawhub/demo", "demo", "write {{OUTPUT_DIR}}/x", 1, {"source": "clawhub"})
+    trusted = RouterHit("hub/demo", "demo", "write {{OUTPUT_DIR}}/x", 1, {"source": "hub"})
+
+    result = search._resolve_placeholders([untrusted, trusted])
+
+    assert result[0].content == "write {{OUTPUT_DIR}}/x"
+    assert result[1].content == "write /workspace/x"
+
+
 class TestLocalStore:
     def test_frontmatter_is_parsed(self, tmp_path: Path) -> None:
         from skillsearch.local_store import DirectorySkillStore

--- a/skillcorpus_plugin/engine-python/tests/test_refs.py
+++ b/skillcorpus_plugin/engine-python/tests/test_refs.py
@@ -1,0 +1,50 @@
+"""Tests for PathGuard placeholder resolution ({{SKILL_DIR}} etc.)."""
+
+from skillsearch.refs import resolve_placeholders
+
+
+def test_skill_dir_and_output() -> None:
+    out = resolve_placeholders(
+        "python {{SKILL_DIR}}/scripts/x.py --out {{OUTPUT_DIR}}/r.csv",
+        "/skills/foo",
+        output_dir=".",
+    )
+    assert out == "python /skills/foo/scripts/x.py --out ./r.csv"
+
+
+def test_named_skill_dir_resolves_to_sibling() -> None:
+    out = resolve_placeholders("see {{SKILL_DIR:other}}/refs/a.md", "/skills/foo")
+    assert out == "see /skills/other/refs/a.md"
+
+
+def test_agent_state_and_home() -> None:
+    out = resolve_placeholders(
+        "cat {{AGENT_STATE_DIR}}/auth/x > {{HOME}}/.cache/y",
+        "/skills/foo",
+        state_dir="/root/.openclaw",
+        home_dir="/root",
+    )
+    assert out == "cat /root/.openclaw/auth/x > /root/.cache/y"
+
+
+def test_state_and_home_fall_back_to_output_dir() -> None:
+    out = resolve_placeholders(
+        "cat {{AGENT_STATE_DIR}}/auth/x > {{HOME}}/.cache/y",
+        "/skills/foo",
+        output_dir=".",
+    )
+    assert out == "cat ./auth/x > ./.cache/y"
+
+
+def test_missing_skill_dir_strips_prefix() -> None:
+    out = resolve_placeholders("python {{SKILL_DIR}}/scripts/x.py", None)
+    assert out == "python scripts/x.py"
+
+
+def test_unknown_placeholder_untouched() -> None:
+    out = resolve_placeholders("set {{YOUR_TOKEN}} and go", "/skills/foo")
+    assert out == "set {{YOUR_TOKEN}} and go"
+
+
+def test_no_placeholders_passthrough() -> None:
+    assert resolve_placeholders("plain body", "/skills/foo") == "plain body"

--- a/skillcorpus_plugin/engine-python/tests/test_refs.py
+++ b/skillcorpus_plugin/engine-python/tests/test_refs.py
@@ -36,9 +36,21 @@ def test_state_and_home_fall_back_to_output_dir() -> None:
     assert out == "cat ./auth/x > ./.cache/y"
 
 
-def test_missing_skill_dir_strips_prefix() -> None:
+def test_missing_skill_dir_keeps_placeholder() -> None:
+    # A bundle that did not download must not become a bare relative path —
+    # that would tell the model the files exist.
     out = resolve_placeholders("python {{SKILL_DIR}}/scripts/x.py", None)
-    assert out == "python scripts/x.py"
+    assert out == "python {{SKILL_DIR}}/scripts/x.py"
+
+
+def test_traversal_name_kept_literal() -> None:
+    out = resolve_placeholders("see {{SKILL_DIR:../../secret}}", "/skills/foo")
+    assert out == "see {{SKILL_DIR:../../secret}}"
+
+
+def test_absolute_name_kept_literal() -> None:
+    out = resolve_placeholders("see {{SKILL_DIR:/etc/passwd}}", "/skills/foo")
+    assert out == "see {{SKILL_DIR:/etc/passwd}}"
 
 
 def test_unknown_placeholder_untouched() -> None:

--- a/skillcorpus_plugin/engine-python/tests/test_refs.py
+++ b/skillcorpus_plugin/engine-python/tests/test_refs.py
@@ -53,6 +53,11 @@ def test_absolute_name_kept_literal() -> None:
     assert out == "see {{SKILL_DIR:/etc/passwd}}"
 
 
+def test_named_skill_dir_rejects_dot_components() -> None:
+    assert resolve_placeholders("see {{SKILL_DIR:.}}/x", "/skills/foo") == "see {{SKILL_DIR:.}}/x"
+    assert resolve_placeholders("see {{SKILL_DIR:..}}/x", "/skills/foo") == "see {{SKILL_DIR:..}}/x"
+
+
 def test_unknown_placeholder_untouched() -> None:
     out = resolve_placeholders("set {{YOUR_TOKEN}} and go", "/skills/foo")
     assert out == "set {{YOUR_TOKEN}} and go"

--- a/skillcorpus_plugin/engine-typescript/src/engine.ts
+++ b/skillcorpus_plugin/engine-typescript/src/engine.ts
@@ -45,6 +45,14 @@ export interface EngineOptions {
    */
   readonly resolveRefs?: boolean
   /**
+   * Expand PathGuard placeholders (`{{SKILL_DIR}}`, `{{HOME}}`, …) in skill
+   * bodies to real host paths. Off by default: it maps a machine-agnostic
+   * placeholder onto this host's filesystem, so it should only be turned on
+   * for a corpus that a trusted PathGuard pass produced — never for arbitrary
+   * third-party skills.
+   */
+  readonly resolvePlaceholders?: boolean
+  /**
    * The agent's writable output directory, for `{{OUTPUT_DIR}}`. Empty
    * resolves to `workspace` at substitution time.
    */
@@ -137,6 +145,7 @@ export class SkillSearchEngine {
   private readonly dedupBy: 'name' | 'qualifiedId'
   private readonly heading: string
   private readonly refs: boolean
+  private readonly placeholders: boolean
   private readonly runtime: PlaceholderRuntime
 
   constructor(parts: EngineParts, options: EngineOptions = {}) {
@@ -154,6 +163,7 @@ export class SkillSearchEngine {
     this.dedupBy = options.dedupBy ?? 'qualifiedId'
     this.heading = options.heading ?? '# Skills'
     this.refs = options.resolveRefs ?? true
+    this.placeholders = options.resolvePlaceholders ?? false
     this.runtime = {
       outputDir: options.outputDir,
       homeDir: options.homeDir,
@@ -322,6 +332,7 @@ export class SkillSearchEngine {
    * hit has its `skillDir` settled.
    */
   private resolvePlaceholders(hits: RouterHit[]): RouterHit[] {
+    if (!this.placeholders) return hits
     return hits.map((hit) => {
       const content = hit.content
       if (!content || !content.includes('{{')) return hit

--- a/skillcorpus_plugin/engine-typescript/src/engine.ts
+++ b/skillcorpus_plugin/engine-typescript/src/engine.ts
@@ -17,7 +17,7 @@ import { createHash } from 'node:crypto'
 
 import { rrfMergeWeighted, type SourceResult } from './fusion.js'
 import { LLMGateFilter } from './gate.js'
-import { resolveRefs } from './refs.js'
+import { resolvePlaceholders, resolveRefs, type PlaceholderRuntime } from './refs.js'
 import { QueryRewriter } from './rewriter.js'
 import type { RouterHit, SkillSource } from './types.js'
 
@@ -44,6 +44,18 @@ export interface EngineOptions {
    * would promise files the model cannot open.
    */
   readonly resolveRefs?: boolean
+  /**
+   * The agent's writable output directory, for `{{OUTPUT_DIR}}`. Empty
+   * resolves to `workspace` at substitution time.
+   */
+  readonly outputDir?: string
+  /** The agent's home directory, for `{{HOME}}`. */
+  readonly homeDir?: string
+  /**
+   * The agent's own config/state root, for `{{AGENT_STATE_DIR}}`
+   * (`~/.openclaw`, `~/.hermes` …). Empty means the agent has no such concept.
+   */
+  readonly stateDir?: string
 }
 
 /** Per-turn inputs, which vary by agent and by cancellation. */
@@ -125,6 +137,7 @@ export class SkillSearchEngine {
   private readonly dedupBy: 'name' | 'qualifiedId'
   private readonly heading: string
   private readonly refs: boolean
+  private readonly runtime: PlaceholderRuntime
 
   constructor(parts: EngineParts, options: EngineOptions = {}) {
     this.sources = parts.sources
@@ -141,6 +154,11 @@ export class SkillSearchEngine {
     this.dedupBy = options.dedupBy ?? 'qualifiedId'
     this.heading = options.heading ?? '# Skills'
     this.refs = options.resolveRefs ?? true
+    this.runtime = {
+      outputDir: options.outputDir,
+      homeDir: options.homeDir,
+      stateDir: options.stateDir,
+    }
   }
 
   /** Whether anything is configured to search. */
@@ -230,7 +248,7 @@ export class SkillSearchEngine {
     }
     // The remote half stays here: extracting a bundle is a download, so it
     // waits until the gate has decided what is actually going in.
-    return this.resolveHitRefs(hits.slice(0, this.topK), signal)
+    return this.resolvePlaceholders(await this.resolveHitRefs(hits.slice(0, this.topK), signal))
   }
 
   private diagnose(diagnostic: SourceDiagnostic): void {
@@ -293,6 +311,24 @@ export class SkillSearchEngine {
       const { body } = resolveRefs(current.content, skillDir)
       return body === current.content ? current : { ...current, content: body }
     }))
+  }
+
+  /**
+   * Fill PathGuard placeholders (`{{SKILL_DIR}}`, `{{HOME}}`, …) per agent.
+   *
+   * Unlike `resolveLocalRefs` / `resolveHitRefs` this never touches the
+   * filesystem and is not gated by `resolveRefs`: a placeholder already names
+   * its target, and only the host knows it. It runs last, once every surviving
+   * hit has its `skillDir` settled.
+   */
+  private resolvePlaceholders(hits: RouterHit[]): RouterHit[] {
+    return hits.map((hit) => {
+      const content = hit.content
+      if (!content || !content.includes('{{')) return hit
+      const skillDir = typeof hit.meta.skillDir === 'string' ? hit.meta.skillDir : undefined
+      const body = resolvePlaceholders(content, skillDir, this.runtime)
+      return body === content ? hit : { ...hit, content: body }
+    })
   }
 
   /** Fill in bodies for hits a source returned as metadata only. */

--- a/skillcorpus_plugin/engine-typescript/src/engine.ts
+++ b/skillcorpus_plugin/engine-typescript/src/engine.ts
@@ -335,7 +335,9 @@ export class SkillSearchEngine {
     if (!this.placeholders) return hits
     return hits.map((hit) => {
       const content = hit.content
-      if (!content || !content.includes('{{')) return hit
+      const source = String(hit.meta.source ?? '')
+      const trusted = ['local', 'builtin', 'hub'].includes(source) || hit.meta.pathguardProcessed === true
+      if (!trusted || !content || !content.includes('{{')) return hit
       const skillDir = typeof hit.meta.skillDir === 'string' ? hit.meta.skillDir : undefined
       const body = resolvePlaceholders(content, skillDir, this.runtime)
       return body === content ? hit : { ...hit, content: body }

--- a/skillcorpus_plugin/engine-typescript/src/index.ts
+++ b/skillcorpus_plugin/engine-typescript/src/index.ts
@@ -137,6 +137,8 @@ export interface Config {
    * skills it retrieves.
    */
   resolveRefs?: boolean
+  /** Expand PathGuard placeholders in trusted skill bodies. Off by default. */
+  resolvePlaceholders?: boolean
 }
 
 export const Config: z<Config> = z.object({
@@ -161,6 +163,7 @@ export const Config: z<Config> = z.object({
   rewriteTimeoutMs: z.number().default(5_000),
   gateTimeoutMs: z.number().default(20_000),
   resolveRefs: z.boolean().default(true),
+  resolvePlaceholders: z.boolean().default(false),
 })
 
 /** Marks the messages this plugin publishes. */
@@ -329,6 +332,9 @@ function buildEngine(ctx: Context, cfg: Config): SkillSearchEngine {
       topK: cfg.topK ?? 2,
       gatePool: cfg.gatePool ?? 10,
       resolveRefs: cfg.resolveRefs ?? true,
+      resolvePlaceholders: cfg.resolvePlaceholders ?? false,
+      homeDir: homedir(),
+      outputDir: process.cwd(),
     },
   )
 }

--- a/skillcorpus_plugin/engine-typescript/src/refs.ts
+++ b/skillcorpus_plugin/engine-typescript/src/refs.ts
@@ -112,7 +112,7 @@ function firstIndexOfAny(text: string, needles: readonly string[]): number {
   return found.length === 0 ? -1 : Math.min(...found)
 }
 
-const PLACEHOLDER_RE = /\{\{([A-Z_]+)(?::([^}]+))?\}\}/g
+const PLACEHOLDER_RE = /\{\{([A-Z_]+)(?::([A-Za-z0-9._-]+))?\}\}/g
 
 /** Per-agent facts that fill the PathGuard placeholders. */
 export interface PlaceholderRuntime {
@@ -134,8 +134,9 @@ export interface PlaceholderRuntime {
  * next to {@link resolveRefs}.
  *
  * - `{{SKILL_DIR}}` → this skill's bundle directory; `{{SKILL_DIR:<n>}}` → a
- *   sibling bundle under the same parent. Without a directory on disk the
- *   prefix is stripped to a bare relative path, matching `resolveRefs`.
+ *   sibling bundle under the same parent. `<n>` is restricted to a safe slug
+ *   (`[A-Za-z0-9._-]+`), so `../../x` or an absolute path does not match and
+ *   stays literal.
  * - `{{AGENT_STATE_DIR}}` → `stateDir`, else `outputDir`.
  * - `{{HOME}}` → `homeDir`, else `outputDir`.
  * - `{{OUTPUT_DIR}}` → `outputDir`.
@@ -152,14 +153,13 @@ export function resolvePlaceholders(
 
   const sd = skillDir || undefined
 
-  // Bare {{SKILL_DIR}} and {{SKILL_DIR}}/… — the slash is folded in so a
-  // missing directory does not leave a leading "/scripts/x.py".
+  // Bare {{SKILL_DIR}} and {{SKILL_DIR}}/… — the slash is folded in so the
+  // directory is written once. Without a directory on disk the placeholder is
+  // left literal, not stripped: a bare `scripts/x.py` would tell the model the
+  // bundle is present when it never downloaded.
   if (sd) {
     body = body.replaceAll('{{SKILL_DIR}}/', `${sd.replace(/\/+$/, '')}/`)
     body = body.replaceAll('{{SKILL_DIR}}', sd)
-  } else {
-    body = body.replaceAll('{{SKILL_DIR}}/', '')
-    body = body.replaceAll('{{SKILL_DIR}}', '')
   }
 
   return body.replace(PLACEHOLDER_RE, (match, name: string, arg?: string) => {

--- a/skillcorpus_plugin/engine-typescript/src/refs.ts
+++ b/skillcorpus_plugin/engine-typescript/src/refs.ts
@@ -164,7 +164,7 @@ export function resolvePlaceholders(
 
   return body.replace(PLACEHOLDER_RE, (match, name: string, arg?: string) => {
     if (name === 'SKILL_DIR') {
-      return sd && arg ? join(dirname(sd), arg) : match
+      return sd && arg && arg !== '.' && arg !== '..' ? join(dirname(sd), arg) : match
     }
     if (name === 'AGENT_STATE_DIR') {
       return runtime.stateDir || runtime.outputDir || match

--- a/skillcorpus_plugin/engine-typescript/src/refs.ts
+++ b/skillcorpus_plugin/engine-typescript/src/refs.ts
@@ -19,7 +19,7 @@
  */
 
 import { existsSync, statSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 
 const BUNDLED_DIRS = ['references', 'scripts', 'assets', 'examples']
 
@@ -110,4 +110,71 @@ function isDirectory(path: string): boolean {
 function firstIndexOfAny(text: string, needles: readonly string[]): number {
   const found = needles.map(n => text.indexOf(n)).filter(i => i !== -1)
   return found.length === 0 ? -1 : Math.min(...found)
+}
+
+const PLACEHOLDER_RE = /\{\{([A-Z_]+)(?::([^}]+))?\}\}/g
+
+/** Per-agent facts that fill the PathGuard placeholders. */
+export interface PlaceholderRuntime {
+  /** The agent's own config/state root, for `{{AGENT_STATE_DIR}}`. */
+  readonly stateDir?: string
+  /** The agent's home, for `{{HOME}}`. */
+  readonly homeDir?: string
+  /** The agent's writable output directory, for `{{OUTPUT_DIR}}`. */
+  readonly outputDir?: string
+}
+
+/**
+ * Replace PathGuard placeholders in a skill body with real paths.
+ *
+ * `{{SKILL_DIR}}` / `{{SKILL_DIR:<name>}}` / `{{AGENT_STATE_DIR}}` /
+ * `{{HOME}}` / `{{OUTPUT_DIR}}` are written by an offline pass over a shared
+ * skill library (see `skill_retire_and_classify/pathguard`) that rewrites
+ * hardcoded paths to agent-agnostic placeholders. This fills them per agent,
+ * next to {@link resolveRefs}.
+ *
+ * - `{{SKILL_DIR}}` → this skill's bundle directory; `{{SKILL_DIR:<n>}}` → a
+ *   sibling bundle under the same parent. Without a directory on disk the
+ *   prefix is stripped to a bare relative path, matching `resolveRefs`.
+ * - `{{AGENT_STATE_DIR}}` → `stateDir`, else `outputDir`.
+ * - `{{HOME}}` → `homeDir`, else `outputDir`.
+ * - `{{OUTPUT_DIR}}` → `outputDir`.
+ *
+ * Substitution is unconditional — unlike `resolveRefs` it never checks the
+ * filesystem, because a placeholder already carries its target.
+ */
+export function resolvePlaceholders(
+  body: string,
+  skillDir: string | undefined,
+  runtime: PlaceholderRuntime = {},
+): string {
+  if (!body || !body.includes('{{')) return body
+
+  const sd = skillDir || undefined
+
+  // Bare {{SKILL_DIR}} and {{SKILL_DIR}}/… — the slash is folded in so a
+  // missing directory does not leave a leading "/scripts/x.py".
+  if (sd) {
+    body = body.replaceAll('{{SKILL_DIR}}/', `${sd.replace(/\/+$/, '')}/`)
+    body = body.replaceAll('{{SKILL_DIR}}', sd)
+  } else {
+    body = body.replaceAll('{{SKILL_DIR}}/', '')
+    body = body.replaceAll('{{SKILL_DIR}}', '')
+  }
+
+  return body.replace(PLACEHOLDER_RE, (match, name: string, arg?: string) => {
+    if (name === 'SKILL_DIR') {
+      return sd && arg ? join(dirname(sd), arg) : match
+    }
+    if (name === 'AGENT_STATE_DIR') {
+      return runtime.stateDir || runtime.outputDir || match
+    }
+    if (name === 'HOME') {
+      return runtime.homeDir || runtime.outputDir || match
+    }
+    if (name === 'OUTPUT_DIR') {
+      return runtime.outputDir || match
+    }
+    return match
+  })
 }

--- a/skillcorpus_plugin/engine-typescript/tests/parity.test.ts
+++ b/skillcorpus_plugin/engine-typescript/tests/parity.test.ts
@@ -413,6 +413,26 @@ test('exact normalized-body dedup keeps the local copy without fuzzy matching', 
   assert.deepEqual(hits.map(item => item.qualifiedId), ['local/copy', 'remote/near'])
 })
 
+
+test('PathGuard expansion skips untrusted marketplace hits', async () => {
+  const source: SkillSource = {
+    name: 'mixed', weight: 1,
+    async search() {
+      return [
+        { ...hit('clawhub/demo', 'third party', 1, 'write {{OUTPUT_DIR}}/x'), meta: { source: 'clawhub' } },
+        { ...hit('hub/demo', 'curated', 0.9, 'write {{OUTPUT_DIR}}/y'), meta: { source: 'hub' } },
+      ]
+    },
+  }
+  const hits = await new SkillSearchEngine(
+    { sources: [source] },
+    { topK: 2, resolvePlaceholders: true, outputDir: '/workspace' },
+  ).hits('write')
+
+  assert.equal(hits[0]?.content, 'write {{OUTPUT_DIR}}/x')
+  assert.equal(hits[1]?.content, 'write /workspace/y')
+})
+
 test('source diagnostics distinguish empty results from failures', async () => {
   const diagnostics: import('../src/engine.ts').SourceDiagnostic[] = []
   const empty: SkillSource = {

--- a/skillcorpus_plugin/engine-typescript/tests/parity.test.ts
+++ b/skillcorpus_plugin/engine-typescript/tests/parity.test.ts
@@ -263,6 +263,10 @@ test('PathGuard placeholders resolve per agent, with traversal kept literal', ()
     'see {{SKILL_DIR:../../secret}}')
   assert.equal(resolvePlaceholders('see {{SKILL_DIR:/etc/passwd}}', '/skills/foo'),
     'see {{SKILL_DIR:/etc/passwd}}')
+  assert.equal(resolvePlaceholders('see {{SKILL_DIR:.}}/x', '/skills/foo'),
+    'see {{SKILL_DIR:.}}/x')
+  assert.equal(resolvePlaceholders('see {{SKILL_DIR:..}}/x', '/skills/foo'),
+    'see {{SKILL_DIR:..}}/x')
 
   // Without a directory, the placeholder stays literal — never a bare path
   // that would tell the model the bundle is present when it did not download.

--- a/skillcorpus_plugin/engine-typescript/tests/parity.test.ts
+++ b/skillcorpus_plugin/engine-typescript/tests/parity.test.ts
@@ -21,7 +21,7 @@ import { bounded } from '../src/deadline.ts'
 import { RRF_K, rrfMergeWeighted } from '../src/fusion.ts'
 import { LLMGateFilter } from '../src/gate.ts'
 import { LocalSkillSource, formatSkillText } from '../src/local-source.ts'
-import { resolveRefs } from '../src/refs.ts'
+import { resolvePlaceholders, resolveRefs } from '../src/refs.ts'
 import { QueryRewriter } from '../src/rewriter.ts'
 import { checkKeywordRelevance, queryTerms } from '../src/relevance.ts'
 import { SkillSearchEngine } from '../src/engine.ts'
@@ -240,6 +240,39 @@ test('refs resolve exactly as the Python implementation resolves them', async ()
   // Without a directory, placeholders are stripped to bare relative paths.
   const stripped = resolveRefs('run {baseDir}/scripts/y.sh', undefined)
   assert.deepEqual(stripped, { body: 'run scripts/y.sh', anyResolved: false })
+})
+
+test('PathGuard placeholders resolve per agent, with traversal kept literal', () => {
+  const runtime = { stateDir: '/root/.oc', homeDir: '/root', outputDir: '/ws' }
+
+  const out = resolvePlaceholders(
+    'python {{SKILL_DIR}}/scripts/x.py --out {{OUTPUT_DIR}}/r.csv\n' +
+    'cat {{AGENT_STATE_DIR}}/auth/x > {{HOME}}/.cache/y\n' +
+    'see {{SKILL_DIR:other}}/refs/a.md',
+    '/skills/foo',
+    runtime,
+  )
+  assert.ok(out.includes('python /skills/foo/scripts/x.py'))
+  assert.ok(out.includes('/ws/r.csv'))
+  assert.ok(out.includes('/root/.oc/auth/x'))
+  assert.ok(out.includes('/root/.cache/y'))
+  assert.ok(out.includes('/skills/other/refs/a.md'))
+
+  // A traversal or absolute name must not leave the skill root.
+  assert.equal(resolvePlaceholders('see {{SKILL_DIR:../../secret}}', '/skills/foo'),
+    'see {{SKILL_DIR:../../secret}}')
+  assert.equal(resolvePlaceholders('see {{SKILL_DIR:/etc/passwd}}', '/skills/foo'),
+    'see {{SKILL_DIR:/etc/passwd}}')
+
+  // Without a directory, the placeholder stays literal — never a bare path
+  // that would tell the model the bundle is present when it did not download.
+  assert.equal(resolvePlaceholders('python {{SKILL_DIR}}/scripts/x.py', undefined),
+    'python {{SKILL_DIR}}/scripts/x.py')
+
+  // state/home fall back to output; unknown placeholders stay untouched.
+  assert.equal(resolvePlaceholders('{{AGENT_STATE_DIR}}/x', '/s/f', { outputDir: '/o' }),
+    '/o/x')
+  assert.equal(resolvePlaceholders('{{YOUR_TOKEN}}', '/s/f', runtime), '{{YOUR_TOKEN}}')
 })
 
 test('a timed-out model call is hung up on, not just abandoned', async () => {

--- a/skillcorpus_plugin/plugin-hermes/engine_adapter.py
+++ b/skillcorpus_plugin/plugin-hermes/engine_adapter.py
@@ -158,6 +158,8 @@ def load_config(hermes_home: str) -> SearchConfig:
     raw.setdefault("output_dir", hermes_home)
     raw.setdefault("home_dir", str(Path.home()))
     raw.setdefault("state_dir", hermes_home)
+    # Off by default: only a trusted PathGuard corpus may expand placeholders.
+    raw.setdefault("resolve_placeholders", False)
     return SearchConfig.from_mapping(raw)
 
 

--- a/skillcorpus_plugin/plugin-hermes/engine_adapter.py
+++ b/skillcorpus_plugin/plugin-hermes/engine_adapter.py
@@ -153,6 +153,11 @@ def load_config(hermes_home: str) -> SearchConfig:
     raw.setdefault("skills_dir", str(Path(hermes_home) / "skills"))
     raw.setdefault("clawhub_endpoint", "https://clawhub.ai")
     raw.setdefault("skillhub_cn_endpoint", "https://api.skillhub.cn")
+    # PathGuard placeholders' per-agent facts. Hermes's own config/state root
+    # is `$HERMES_HOME` (the workspace here), and its home is the process home.
+    raw.setdefault("output_dir", hermes_home)
+    raw.setdefault("home_dir", str(Path.home()))
+    raw.setdefault("state_dir", hermes_home)
     return SearchConfig.from_mapping(raw)
 
 

--- a/skillcorpus_plugin/plugin-openclaw/openclaw.plugin.json
+++ b/skillcorpus_plugin/plugin-openclaw/openclaw.plugin.json
@@ -88,6 +88,11 @@
         "default": false,
         "description": "Index skill bodies alongside name and description. Off by default: the description is the retrieval contract of the SKILL.md format, and is also what the gate reads."
       },
+      "resolvePlaceholders": {
+        "type": "boolean",
+        "default": false,
+        "description": "Expand trusted PathGuard placeholders to this agent's paths. Keep disabled for arbitrary third-party skill bodies."
+      },
       "rewrite": {
         "type": "boolean",
         "default": true,

--- a/skillcorpus_plugin/plugin-openclaw/src/config.ts
+++ b/skillcorpus_plugin/plugin-openclaw/src/config.ts
@@ -51,6 +51,12 @@ export interface SkillSearchConfig {
    * here. Empty leaves the gate judging relevance alone.
    */
   readonly availableTools: string[]
+  /**
+   * Expand PathGuard placeholders in skill bodies to real host paths. Off by
+   * default: only a corpus produced by a trusted PathGuard pass should turn
+   * this on, never arbitrary third-party skills.
+   */
+  readonly resolvePlaceholders: boolean
 }
 
 export const DEFAULTS: SkillSearchConfig = {
@@ -71,6 +77,7 @@ export const DEFAULTS: SkillSearchConfig = {
   gate: undefined,
   timeoutMs: 8000,
   availableTools: [],
+  resolvePlaceholders: false,
 }
 
 /** Environment variable for each field a deployment may prefer to keep out of a file. */
@@ -92,6 +99,7 @@ const ENV_KEYS: Partial<Record<keyof SkillSearchConfig, string>> = {
   gate: 'SKILLSEARCH_GATE',
   timeoutMs: 'SKILLSEARCH_TIMEOUT_MS',
   availableTools: 'SKILLSEARCH_AVAILABLE_TOOLS',
+  resolvePlaceholders: 'SKILLSEARCH_RESOLVE_PLACEHOLDERS',
 }
 
 /**
@@ -180,5 +188,6 @@ export function loadConfig(
     gate: asBoolean(pick('gate')),
     timeoutMs: asNumber(pick('timeoutMs')) ?? DEFAULTS.timeoutMs,
     availableTools: asList(pick('availableTools')) ?? DEFAULTS.availableTools,
+    resolvePlaceholders: asBoolean(pick('resolvePlaceholders')) ?? DEFAULTS.resolvePlaceholders,
   }
 }

--- a/skillcorpus_plugin/plugin-openclaw/src/register.ts
+++ b/skillcorpus_plugin/plugin-openclaw/src/register.ts
@@ -196,13 +196,18 @@ export function register(
   // workspace directory is known. Using `process.cwd()` (the host process's
   // cwd) would be wrong for multi-agent hosts and for sessions with a
   // different workspace.
-  let engine: SkillSearchEngine | undefined
+  const engines = new Map<string, SkillSearchEngine>()
 
   api.on('before_prompt_build', async (
     event: BeforePromptBuildEvent,
     ctx: { workspaceDir?: string },
   ): Promise<BeforePromptBuildResult | void> => {
-    engine ??= build(config, ctx?.workspaceDir)
+    const workspaceDir = ctx?.workspaceDir || process.cwd()
+    let engine = engines.get(workspaceDir)
+    if (!engine) {
+      engine = build(config, workspaceDir)
+      engines.set(workspaceDir, engine)
+    }
 
     const query = (event.prompt || '').trim() || recentUserText(event.messages ?? [])
     if (!query) return

--- a/skillcorpus_plugin/plugin-openclaw/src/register.ts
+++ b/skillcorpus_plugin/plugin-openclaw/src/register.ts
@@ -40,7 +40,7 @@ export function expandHome(path: string, home: string = homedir()): string {
  * @returns the engine, which reports `enabled: false` when nothing is
  *   configured to search.
  */
-export function buildEngine(config: SkillSearchConfig): SkillSearchEngine {
+export function buildEngine(config: SkillSearchConfig, workspaceDir?: string): SkillSearchEngine {
   const sources: SkillSource[] = []
 
   const dirs = config.skillsDirs.map(dir => expandHome(dir)).filter(dir => isAbsolute(dir) || dir)
@@ -135,10 +135,12 @@ export function buildEngine(config: SkillSearchConfig): SkillSearchEngine {
       topK: config.topK,
       gatePool: config.gatePool,
       // PathGuard placeholders' per-agent facts. OpenClaw's own config root is
-      // ~/.openclaw; the agent's writable output is its working directory.
-      outputDir: process.cwd(),
+      // ~/.openclaw; the agent's writable output is its workspace, falling back
+      // to the host process's cwd when the hook did not report one.
+      outputDir: workspaceDir || process.cwd(),
       homeDir: homedir(),
       stateDir: join(homedir(), '.openclaw'),
+      resolvePlaceholders: config.resolvePlaceholders,
     },
   )
 }
@@ -181,16 +183,27 @@ export function register(
   deps: { buildEngineFn?: typeof buildEngine } = {},
 ): void {
   const config = loadConfig(api.pluginConfig)
-  const engine = (deps.buildEngineFn ?? buildEngine)(config)
+  const build = deps.buildEngineFn ?? buildEngine
 
-  if (!engine.enabled) {
+  // Probe without a workspace: `enabled` depends only on the sources, not on
+  // the output directory.
+  if (!build(config).enabled) {
     api.logger?.info?.('[skillsearch] no sources configured; retrieval is off')
     return
   }
 
+  // The engine is built lazily on the first hook, where the agent's own
+  // workspace directory is known. Using `process.cwd()` (the host process's
+  // cwd) would be wrong for multi-agent hosts and for sessions with a
+  // different workspace.
+  let engine: SkillSearchEngine | undefined
+
   api.on('before_prompt_build', async (
     event: BeforePromptBuildEvent,
+    ctx: { workspaceDir?: string },
   ): Promise<BeforePromptBuildResult | void> => {
+    engine ??= build(config, ctx?.workspaceDir)
+
     const query = (event.prompt || '').trim() || recentUserText(event.messages ?? [])
     if (!query) return
 

--- a/skillcorpus_plugin/plugin-openclaw/src/register.ts
+++ b/skillcorpus_plugin/plugin-openclaw/src/register.ts
@@ -131,7 +131,15 @@ export function buildEngine(config: SkillSearchConfig): SkillSearchEngine {
         }
         : {}),
     },
-    { topK: config.topK, gatePool: config.gatePool },
+    {
+      topK: config.topK,
+      gatePool: config.gatePool,
+      // PathGuard placeholders' per-agent facts. OpenClaw's own config root is
+      // ~/.openclaw; the agent's writable output is its working directory.
+      outputDir: process.cwd(),
+      homeDir: homedir(),
+      stateDir: join(homedir(), '.openclaw'),
+    },
   )
 }
 

--- a/skillcorpus_plugin/plugin-openclaw/test/register.test.ts
+++ b/skillcorpus_plugin/plugin-openclaw/test/register.test.ts
@@ -11,7 +11,7 @@
  */
 
 import assert from 'node:assert/strict'
-import { mkdtemp, mkdir, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
@@ -129,6 +129,28 @@ test('registers no hook at all when nothing is configured to search', async () =
   const { api, hooks } = fakeApi({ skillsDirs: [] })
   register(api)
   assert.equal(hooks.size, 0)
+})
+
+test('the manifest accepts the placeholder-resolution switch', async () => {
+  const manifest = JSON.parse(await readFile(new URL('../openclaw.plugin.json', import.meta.url), 'utf8'))
+  assert.equal(manifest.configSchema.properties.resolvePlaceholders.type, 'boolean')
+  assert.equal(manifest.configSchema.properties.resolvePlaceholders.default, false)
+})
+
+test('engines are cached per workspace rather than shared across agents', async () => {
+  const builtFor: Array<string | undefined> = []
+  const { api, hooks } = fakeApi({ skillsDirs: ['/skills'] })
+  register(api, {
+    buildEngineFn: (_config, workspaceDir) => {
+      builtFor.push(workspaceDir)
+      return { enabled: true, retrieve: () => Promise.resolve('') } as never
+    },
+  })
+  const hook = hooks.get('before_prompt_build')!
+  await hook({ prompt: 'one', messages: [] }, { workspaceDir: '/workspace/a' })
+  await hook({ prompt: 'two', messages: [] }, { workspaceDir: '/workspace/b' })
+  await hook({ prompt: 'three', messages: [] }, { workspaceDir: '/workspace/a' })
+  assert.deepEqual(builtFor, [undefined, '/workspace/a', '/workspace/b'])
 })
 
 test('a retrieval that throws costs the turn its skills, not the turn', async () => {

--- a/skillcorpus_plugin/plugin-raven/skillsearch_raven/__init__.py
+++ b/skillcorpus_plugin/plugin-raven/skillsearch_raven/__init__.py
@@ -125,6 +125,9 @@ def make_segment(ctx: Any) -> Any | None:
     cfg_map.setdefault("output_dir", workspace)
     cfg_map.setdefault("home_dir", workspace)
     cfg_map.setdefault("state_dir", "")
+    # Off by default: only a corpus produced by a trusted PathGuard pass may
+    # expand placeholders onto this host's real filesystem paths.
+    cfg_map.setdefault("resolve_placeholders", False)
     config = SearchConfig.from_mapping(cfg_map)
 
     # Raven passes live objects through the config slice under private

--- a/skillcorpus_plugin/plugin-raven/skillsearch_raven/__init__.py
+++ b/skillcorpus_plugin/plugin-raven/skillsearch_raven/__init__.py
@@ -119,6 +119,12 @@ def make_segment(ctx: Any) -> Any | None:
     cfg_map.setdefault("agent_id", getattr(services, "agent_id", "") or "")
     cfg_map.setdefault("clawhub_endpoint", "https://clawhub.ai")
     cfg_map.setdefault("skillhub_cn_endpoint", "https://api.skillhub.cn")
+    # PathGuard placeholders' per-agent facts. Raven has no persistent
+    # config/state root of its own, and the agent's writable home is the
+    # workspace, so both {{HOME}} and {{AGENT_STATE_DIR}} collapse there.
+    cfg_map.setdefault("output_dir", workspace)
+    cfg_map.setdefault("home_dir", workspace)
+    cfg_map.setdefault("state_dir", "")
     config = SearchConfig.from_mapping(cfg_map)
 
     # Raven passes live objects through the config slice under private

--- a/skillcorpus_plugin/plugin-raven/skillsearch_raven/raven-plugin.toml
+++ b/skillcorpus_plugin/plugin-raven/skillsearch_raven/raven-plugin.toml
@@ -45,4 +45,5 @@ gate_timeout_s = { type = "number",  default = 20.0 }
 
 # Output.
 resolve_refs = { type = "boolean", default = true }
+resolve_placeholders = { type = "boolean", default = false }
 heading      = { type = "string",  default = "# Skills" }

--- a/skillcorpus_plugin/plugin-workbuddy/src/config.ts
+++ b/skillcorpus_plugin/plugin-workbuddy/src/config.ts
@@ -56,6 +56,12 @@ export interface SkillSearchConfig {
   readonly indexCachePath: string
   /** Append one JSON line per turn here. Empty disables the log. */
   readonly logPath: string
+  /**
+   * Expand PathGuard placeholders in skill bodies to real host paths. Off by
+   * default: only a corpus produced by a trusted PathGuard pass should turn
+   * this on, never arbitrary third-party skills.
+   */
+  readonly resolvePlaceholders: boolean
 }
 
 /** Where a marketplace-installed hook lives, which is where its name is. */
@@ -150,6 +156,7 @@ export const DEFAULTS: SkillSearchConfig = {
   rrfK: 10,
   indexCachePath: join(DATA_DIR, 'index-cache.json'),
   logPath: join(DATA_DIR, 'skillsearch.log'),
+  resolvePlaceholders: false,
 }
 
 const ENV_KEYS: Partial<Record<keyof SkillSearchConfig, string>> = {
@@ -175,6 +182,7 @@ const ENV_KEYS: Partial<Record<keyof SkillSearchConfig, string>> = {
   rrfK: 'SKILLSEARCH_RRF_K',
   indexCachePath: 'SKILLSEARCH_INDEX_CACHE_PATH',
   logPath: 'SKILLSEARCH_LOG_PATH',
+  resolvePlaceholders: 'SKILLSEARCH_RESOLVE_PLACEHOLDERS',
 }
 
 function asList(value: unknown): string[] | undefined {
@@ -278,5 +286,6 @@ export function loadConfig(
     rrfK: asNumber(pick('rrfK')) ?? DEFAULTS.rrfK,
     indexCachePath: asText(pick('indexCachePath')) ?? DEFAULTS.indexCachePath,
     logPath: asText(pick('logPath')) ?? DEFAULTS.logPath,
+    resolvePlaceholders: asBoolean(pick('resolvePlaceholders')) ?? DEFAULTS.resolvePlaceholders,
   }
 }

--- a/skillcorpus_plugin/plugin-workbuddy/src/hook.ts
+++ b/skillcorpus_plugin/plugin-workbuddy/src/hook.ts
@@ -119,7 +119,7 @@ export async function runTurn(
   if (query) {
     try {
       block = await (deps.retrieveFn ?? retrieveForTurn)(
-        query, config, {}, diagnostic => { sourceDiagnostics.push(diagnostic) },
+        query, config, {}, diagnostic => { sourceDiagnostics.push(diagnostic) }, payload.cwd,
       )
     } catch (error) {
       // `retrieveForTurn` already promises never to reject. This is the

--- a/skillcorpus_plugin/plugin-workbuddy/src/retrieve.ts
+++ b/skillcorpus_plugin/plugin-workbuddy/src/retrieve.ts
@@ -37,6 +37,7 @@ export function expandHome(path: string, home: string = homedir()): string {
 export function buildEngine(
   config: SkillSearchConfig,
   onDiagnostic?: (diagnostic: SourceDiagnostic) => void,
+  workspaceDir?: string,
 ): SkillSearchEngine {
   const sources: SkillSource[] = []
 
@@ -136,10 +137,12 @@ export function buildEngine(
       gatePool: config.gatePool,
       rrfK: config.rrfK,
       // PathGuard placeholders' per-agent facts. WorkBuddy's own config root
-      // is ~/.workbuddy-ai; the agent's writable output is its working dir.
-      outputDir: process.cwd(),
+      // is ~/.workbuddy-ai; the agent's writable output is its workspace,
+      // falling back to the hook process's cwd when the payload reports none.
+      outputDir: workspaceDir || process.cwd(),
       homeDir: homedir(),
       stateDir: join(homedir(), '.workbuddy-ai'),
+      resolvePlaceholders: config.resolvePlaceholders,
     },
   )
 }
@@ -161,12 +164,13 @@ export async function retrieveForTurn(
   config: SkillSearchConfig,
   deps: { buildEngineFn?: typeof buildEngine } = {},
   onDiagnostic?: (diagnostic: SourceDiagnostic) => void,
+  workspaceDir?: string,
 ): Promise<string> {
   if (!query.trim()) return ''
 
   let engine: SkillSearchEngine
   try {
-    engine = (deps.buildEngineFn ?? buildEngine)(config, onDiagnostic)
+    engine = (deps.buildEngineFn ?? buildEngine)(config, onDiagnostic, workspaceDir)
   } catch {
     return ''
   }

--- a/skillcorpus_plugin/plugin-workbuddy/src/retrieve.ts
+++ b/skillcorpus_plugin/plugin-workbuddy/src/retrieve.ts
@@ -131,7 +131,16 @@ export function buildEngine(
         }
         : {}),
     },
-    { topK: config.topK, gatePool: config.gatePool, rrfK: config.rrfK },
+    {
+      topK: config.topK,
+      gatePool: config.gatePool,
+      rrfK: config.rrfK,
+      // PathGuard placeholders' per-agent facts. WorkBuddy's own config root
+      // is ~/.workbuddy-ai; the agent's writable output is its working dir.
+      outputDir: process.cwd(),
+      homeDir: homedir(),
+      stateDir: join(homedir(), '.workbuddy-ai'),
+    },
   )
 }
 


### PR DESCRIPTION
## Summary

Add runtime resolution for PathGuard placeholders in retrieved skill bodies.

Supported placeholders:

- `{{SKILL_DIR}}`
- `{{SKILL_DIR:<name>}}`
- `{{AGENT_STATE_DIR}}`
- `{{HOME}}`
- `{{OUTPUT_DIR}}`

The Python and TypeScript retrieval engines resolve these placeholders using paths supplied by each agent integration. OpenClaw, WorkBuddy, Hermes, and Raven adapters are supported.

## Compatibility

Placeholder resolution is disabled by default and must be explicitly enabled with:

- Python: `resolve_placeholders=true`
- TypeScript: `resolvePlaceholders=true`

Existing corpus data is unaffected. When a skill body contains no supported placeholders, its content is returned unchanged. This allows the plugin change to be released before the PathGuard-processed corpus snapshot is published.

## Safety

- Unknown or malformed placeholders remain unchanged.
- Named skill references reject traversal and absolute-path patterns.
- `{{SKILL_DIR}}` remains unchanged when no downloaded skill directory is available.
- Resolution only runs after retrieval and reference hydration.

## Testing

Added Python and TypeScript tests covering:

- Standard placeholder replacement
- Per-agent runtime paths
- Named sibling skill directories
- Missing skill directories
- Unknown placeholders
- Path traversal and absolute-path rejection