### PR TITLE
docs: add EverMind ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,53 +319,76 @@ python -m pytest skillcorpus/tests -p no:cacheprovider --import-mode=importlib
 
 ## EverMind Ecosystem
 
-EverMind is an open-source ecosystem for long-term memory, self-evolving agents, AI-native interfaces, and memory evaluation.
+EverMind connects memory research, production-ready products, and practical
+integrations into one open-source ecosystem.
 
 <table>
 <tr>
-<th colspan="2">EverMind Open-Source Ecosystem</th>
+<th colspan="2">Products</th>
 </tr>
 <tr>
-<td><strong>Memory Runtime</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverOS">EverOS</a> — the local memory operating system and research-backed runtime for agent and user memory.</td>
+<td><strong><a href="https://github.com/EverMind-AI/EverOS">EverOS</a></strong></td>
+<td>A local-first, Markdown-native long-term memory runtime for agents and users.</td>
 </tr>
 <tr>
-<td><strong>Self-Improving Agent Harness</strong></td>
-<td><a href="https://github.com/EverMind-AI/Raven">Raven</a> — the self-improving agent harness that brings memory, proactivity, context control, and skill evolution into terminal-native agents.</td>
+<td><strong><a href="https://github.com/EverMind-AI/Raven">Raven</a></strong></td>
+<td>A memory-first, self-improving agent harness with proactivity, context control, and skill evolution.</td>
 </tr>
 <tr>
-<td><strong>Agent Skills &amp; Retrieval</strong></td>
-<td><a href="https://github.com/EverMind-AI/SkillCorpus">SkillCorpus</a> — open curation and retrieval tooling, a public <a href="https://huggingface.co/datasets/EverMind-AI/skillcorpus-demo-1k">1K demo corpus</a>, <a href="https://evermind.ai/skillhub">SkillHub</a>, agent integrations, and benchmarks.</td>
+<td><strong><a href="https://github.com/EverMind-AI/EverMe">EverMe (CLI)</a></strong></td>
+<td>A CLI and agent plugin suite for cross-device, cross-agent personal memory.</td>
 </tr>
 <tr>
-<td><strong>Algorithm Engine</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a> — stateless extraction, ranking, parsing, and memory operators that power EverOS.</td>
+<th colspan="2">Research &amp; Evaluation</th>
 </tr>
 <tr>
-<td><strong>Hypergraph Memory</strong></td>
-<td><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a> — hypergraph memory for long-term conversations, with its own benchmark-backed topic → episode → fact retrieval method.</td>
+<td><strong><a href="https://github.com/EverMind-AI/SkillCorpus">SkillCorpus</a></strong></td>
+<td>Curated, retrieval-ready agent skill corpora with retrieval and evaluation tooling.</td>
 </tr>
 <tr>
-<td><strong>Benchmarks</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a> · <a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a> — evaluation suites for conversational memory and agent self-evolution.</td>
+<td><strong><a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a></strong></td>
+<td>Stateless extraction, ranking, parsing, and memory operators that power EverOS.</td>
 </tr>
 <tr>
-<td><strong>Long-Context Research</strong></td>
-<td><a href="https://github.com/EverMind-AI/MSA">MSA</a> — Memory Sparse Attention for scalable latent memory and 100M-token contexts.</td>
+<td><strong><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a></strong></td>
+<td>Hypergraph-based hierarchical memory for coarse-to-fine long-term conversation retrieval.</td>
 </tr>
 <tr>
-<td><strong>Personal Memory Layer</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverMe">EverMe</a> — CLI and agent plugin suite for cross-device, cross-agent personal memory.</td>
+<td><strong><a href="https://github.com/EverMind-AI/MSA">MSA</a></strong></td>
+<td>Memory Sparse Attention for scalable latent memory and 100M-token contexts.</td>
 </tr>
 <tr>
-<td><strong>Developer Integrations</strong></td>
-<td><a href="https://github.com/EverMind-AI/evermem-claude-code">evermem-claude-code</a> · <a href="https://github.com/EverMind-AI/everos-plugins">everos-plugins</a> — plugins, skills, and migration tooling for AI coding agents.</td>
+<td><strong><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a></strong></td>
+<td>Evaluation of factual recall, applied reasoning, and personalized generalization in memory systems.</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a></strong></td>
+<td>Longitudinal evaluation of agent self-evolution, transfer efficiency, error avoidance, and skill use.</td>
+</tr>
+<tr>
+<th colspan="2"><a href="https://github.com/EverMind-AI/plugins">Integrations</a></th>
+</tr>
+<tr>
+<td><strong><a href="https://docs.openclaw.ai">OpenClaw</a></strong></td>
+<td><a href="https://github.com/EverMind-AI/plugins/tree/main/openclaw">OpenClaw plugin</a> for automatic recall, capture, and session-memory lifecycle management.</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a></strong></td>
+<td><a href="https://github.com/EverMind-AI/plugins/tree/main/hermes">Hermes plugin</a> for persistent memory across Hermes sessions.</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/deepseek-ai/DeepSeek-Harness">DeepSeek Harness</a></strong></td>
+<td><a href="https://github.com/EverMind-AI/plugins/tree/main/dsh">DSH plugin</a> for memory-aware DeepSeek Harness agents.</td>
+</tr>
+<tr>
+<td><strong><a href="https://dify.ai">Dify</a></strong></td>
+<td><a href="https://github.com/EverMind-AI/plugins/tree/main/dify">Self-hosted</a> and <a href="https://github.com/EverMind-AI/plugins/tree/main/dify_cloud">cloud</a> tools for explicit memory search and storage in workflows and agents.</td>
 </tr>
 </table>
 
-Together, these repositories form EverMind's research-to-runtime stack: new memory methods, reusable algorithms, benchmark evidence, and practical agent integrations.
-
-<br>
+Together, these projects form EverMind's research-to-runtime stack: methods
+and benchmarks become reusable memory infrastructure, products, and agent
+integrations.
 
 ## Citation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -298,55 +298,76 @@ python -m pytest skillcorpus/tests -p no:cacheprovider --import-mode=importlib
 
 <br>
 
-## EverMind 生态系统
+## EverMind 生态
 
-EverMind 是一个面向长期记忆、自我演进 agent、AI 原生界面和记忆评估的开源生态系统。
+EverMind 将记忆研究、可直接使用的产品与实际集成连接为一个开源生态。
 
 <table>
 <tr>
-<th colspan="2">EverMind 开源生态系统</th>
+<th colspan="2">产品</th>
 </tr>
 <tr>
-<td><strong>记忆运行时</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverOS">EverOS</a> —— 面向 agent 与用户记忆的本地记忆操作系统和研究支撑运行时。</td>
+<td><strong><a href="https://github.com/EverMind-AI/EverOS">EverOS</a></strong></td>
+<td>本地优先、Markdown 原生的 Agent 与用户长期记忆运行时。</td>
 </tr>
 <tr>
-<td><strong>自我改进 Agent Harness</strong></td>
-<td><a href="https://github.com/EverMind-AI/Raven">Raven</a> —— 将记忆、主动性、上下文控制和技能演进带入终端原生 agent 的 harness。</td>
+<td><strong><a href="https://github.com/EverMind-AI/Raven">Raven</a></strong></td>
+<td>以记忆为核心的自进化 Agent Harness，具备主动性、上下文控制与 Skill 进化能力。</td>
 </tr>
 <tr>
-<td><strong>Agent 技能与检索</strong></td>
-<td><a href="https://github.com/EverMind-AI/SkillCorpus">SkillCorpus</a> —— 开放策展与检索工具、公开的 <a href="https://huggingface.co/datasets/EverMind-AI/skillcorpus-demo-1k">1K demo 语料</a>、<a href="https://evermind.ai/skillhub">SkillHub</a>、agent 集成和基准测试。</td>
+<td><strong><a href="https://github.com/EverMind-AI/EverMe">EverMe（CLI）</a></strong></td>
+<td>面向跨设备、跨 Agent 个人记忆的 CLI 与 Agent 插件套件。</td>
 </tr>
 <tr>
-<td><strong>算法引擎</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a> —— 为 EverOS 提供支持的无状态提取、排序、解析和记忆算子。</td>
+<th colspan="2">研究与评测</th>
 </tr>
 <tr>
-<td><strong>超图记忆</strong></td>
-<td><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a> —— 面向长期对话的超图记忆，提供经过基准验证的主题 → episode → 事实检索方法。</td>
+<td><strong><a href="https://github.com/EverMind-AI/SkillCorpus">SkillCorpus</a></strong></td>
+<td>将分散的 Agent Skill 整理为可检索语料库，并提供检索与评测工具。</td>
 </tr>
 <tr>
-<td><strong>评测基准</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a> · <a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a> —— 对话记忆和 agent 自我演进的评估套件。</td>
+<td><strong><a href="https://github.com/EverMind-AI/EverAlgo">EverAlgo</a></strong></td>
+<td>为 EverOS 提供无状态的提取、排序、解析与记忆算法。</td>
 </tr>
 <tr>
-<td><strong>长上下文研究</strong></td>
-<td><a href="https://github.com/EverMind-AI/MSA">MSA</a> —— 面向可扩展潜在记忆和 100M token 上下文的 Memory Sparse Attention。</td>
+<td><strong><a href="https://github.com/EverMind-AI/HyperMem">HyperMem</a></strong></td>
+<td>基于超图的分层记忆架构，用于由粗到细的长期对话检索。</td>
 </tr>
 <tr>
-<td><strong>个人记忆层</strong></td>
-<td><a href="https://github.com/EverMind-AI/EverMe">EverMe</a> —— 面向跨设备、跨 agent 个人记忆的 CLI 与 agent 插件套件。</td>
+<td><strong><a href="https://github.com/EverMind-AI/MSA">MSA</a></strong></td>
+<td>面向可扩展潜在记忆与一亿 Token 上下文的 Memory Sparse Attention。</td>
 </tr>
 <tr>
-<td><strong>开发者集成</strong></td>
-<td><a href="https://github.com/EverMind-AI/evermem-claude-code">evermem-claude-code</a> · <a href="https://github.com/EverMind-AI/everos-plugins">everos-plugins</a> —— 面向 AI 编程 agent 的插件、技能与迁移工具。</td>
+<td><strong><a href="https://github.com/EverMind-AI/EverMemBench">EverMemBench</a></strong></td>
+<td>从事实召回、应用推理和个性化泛化三个层面评测记忆系统。</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/EverMind-AI/EvoAgentBench">EvoAgentBench</a></strong></td>
+<td>纵向评测 Agent 自进化、迁移效率、错误规避和 Skill 使用能力。</td>
+</tr>
+<tr>
+<th colspan="2"><a href="https://github.com/EverMind-AI/plugins">插件与集成</a></th>
+</tr>
+<tr>
+<td><strong><a href="https://docs.openclaw.ai">OpenClaw</a></strong></td>
+<td><a href="https://github.com/EverMind-AI/plugins/tree/main/openclaw">OpenClaw 插件</a>，自动管理召回、写入与会话记忆生命周期。</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a></strong></td>
+<td><a href="https://github.com/EverMind-AI/plugins/tree/main/hermes">Hermes 插件</a>，为 Hermes 会话提供持久记忆。</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/deepseek-ai/DeepSeek-Harness">DeepSeek Harness</a></strong></td>
+<td><a href="https://github.com/EverMind-AI/plugins/tree/main/dsh">DSH 插件</a>，让 DeepSeek Harness Agent 使用长期记忆。</td>
+</tr>
+<tr>
+<td><strong><a href="https://dify.ai">Dify</a></strong></td>
+<td><a href="https://github.com/EverMind-AI/plugins/tree/main/dify">本地版</a>与<a href="https://github.com/EverMind-AI/plugins/tree/main/dify_cloud">云端版</a>工具，在工作流和 Agent 中显式搜索与写入记忆。</td>
 </tr>
 </table>
 
-这些仓库共同构成 EverMind 从研究到运行时的技术栈：新的记忆方法、可复用算法、基准证据与实用的 agent 集成。
-
-<br>
+这些项目共同构成 EverMind 从研究到运行时的完整链路：将方法与评测转化为
+可复用的记忆基础设施、产品和 Agent 集成。
 
 ## 引用
 


### PR DESCRIPTION
## Summary

- Add the shared EverMind Ecosystem section from EverOS to the English and Chinese README files.
- Keep product, research, and integration links consistent across public repositories.
- Place the section near the lower documentation area.

## Validation

- Documentation-only change.
- Verified one ecosystem section per README with the exact shared table content.
- No runtime tests were run.