### PR TITLE
fix(release): enable v0.1.0 publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,9 @@ name: Release
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+*"
+      # GitHub Actions uses glob patterns here, not regular expressions.
+      # The publish job below still requires an exact v<pyproject version> match.
+      - "v*"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Match standard root-package release tags such as v0.1.0.
- Keep the existing exact version guard: the tag must equal the version in pyproject.toml.

## Validation

- git diff --check
- Verified v0.1.0 matches the workflow trigger, while skillcorpus-plugins-v0.2.0 does not.
- Existing CI will run repository gates, tests, package build, and package-content checks.

Closes #13.