### PR TITLE
chore(release): prepare SkillCorpus v0.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,60 +1,143 @@
-# Publishes the root ``skillcorpus`` package through PyPI Trusted Publishing,
-# then creates a GitHub Release. A tag is the explicit release approval;
-# merging a normal pull request never publishes a package.
+# Builds every release artifact on a release PR or manual run. A vX.Y.Z tag
+# is the explicit publication approval: tag runs also create the GitHub Release
+# and publish the root Python distribution through PyPI Trusted Publishing.
 name: Release
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/release.yml"
+      - "pyproject.toml"
+      - "skillcorpus/__init__.py"
+      - "skillcorpus_plugin/**"
+  workflow_dispatch:
   push:
     tags:
-      # GitHub Actions uses glob patterns here, not regular expressions.
-      # The publish job below still requires an exact v<pyproject version> match.
       - "v*"
 
 permissions:
   contents: read
 
 jobs:
-  publish:
-    name: build + publish to PyPI
+  build:
+    name: build release artifacts
     runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Verify tag matches package version
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: |
+            skillcorpus_plugin/plugin-openclaw/package-lock.json
+            skillcorpus_plugin/plugin-openclaw2/package-lock.json
+            skillcorpus_plugin/plugin-workbuddy/package-lock.json
+
+      - name: Verify release versions
+        shell: bash
         run: |
-          tag="${GITHUB_REF_NAME#v}"
-          version="$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")"
-          test "$tag" = "$version" || {
-            echo "::error::tag v$tag does not match pyproject.toml version $version"
-            exit 1
-          }
-      - run: python -m pip install --upgrade pip build
-      - run: python -m build
-      - run: python scripts/check_package_contents.py dist/*.whl
-      - name: Publish to PyPI with OIDC
-        uses: pypa/gh-action-pypi-publish@release/v1
+          version="$(python3 -c "import tomllib; print(tomllib.load(open(\"pyproject.toml\", \"rb\"))[\"project\"][\"version\"])")"
+          if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+            test "$GITHUB_REF_NAME" = "v$version" || {
+              echo "::error::tag $GITHUB_REF_NAME does not match package version $version"
+              exit 1
+            }
+          fi
+          python skillcorpus_plugin/scripts/verify_release_versions.py
+
+      - name: Build Python distributions
+        run: |
+          python -m pip install --upgrade pip build twine
+          mkdir -p release-assets/python-root release-assets/python-plugins
+          python -m build --outdir release-assets/python-root .
+          python scripts/check_package_contents.py release-assets/python-root/*.whl
+          python -m build --outdir release-assets/python-plugins skillcorpus_plugin/engine-python
+          python -m build --outdir release-assets/python-plugins skillcorpus_plugin/plugin-raven
+          python -m twine check release-assets/python-root/* release-assets/python-plugins/*
+
+      - name: Build TypeScript distributions
+        shell: bash
+        run: |
+          mkdir -p release-assets/npm
+          for package in plugin-openclaw plugin-openclaw2 plugin-workbuddy; do
+            npm ci --prefix "skillcorpus_plugin/$package"
+            npm run --prefix "skillcorpus_plugin/$package" build
+            node skillcorpus_plugin/scripts/verify_npm_package.mjs "skillcorpus_plugin/$package"
+            (
+              cd "skillcorpus_plugin/$package"
+              npm pack --pack-destination "$GITHUB_WORKSPACE/release-assets/npm"
+            )
+          done
+
+      - name: Build complete plugin bundle and checksums
+        shell: bash
+        run: |
+          version="$(python3 -c "import tomllib; print(tomllib.load(open(\"pyproject.toml\", \"rb\"))[\"project\"][\"version\"])")"
+          tar \
+            --exclude=node_modules \
+            --exclude=__pycache__ \
+            --exclude="*.pyc" \
+            -czf "release-assets/skillcorpus-plugins-v${version}.tar.gz" \
+            .codebuddy-plugin skillcorpus_plugin LICENSE
+          (
+            cd release-assets
+            find . -type f ! -name SHA256SUMS -print0 \
+              | sort -z \
+              | xargs -0 sha256sum > SHA256SUMS
+          )
+
+      - name: Verify packaged plugin versions and licenses
+        run: python skillcorpus_plugin/scripts/verify_release_versions.py
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-assets
+          path: release-assets
+          if-no-files-found: error
+
+  publish-pypi:
+    name: publish root package to PyPI
+    if: github.event_name == "push" && github.ref_type == "tag"
+    needs: build
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-assets
+          path: release-assets
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: release-assets/python-root/
 
   github-release:
-    name: create the GitHub Release
-    needs: publish
+    name: create GitHub Release
+    if: github.event_name == "push" && github.ref_type == "tag"
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
-      - name: Create a release if one does not already exist
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-assets
+          path: release-assets
+      - name: Create or update release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
+        shell: bash
         run: |
+          mapfile -d "" files < <(find release-assets -type f -print0 | sort -z)
           if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release $TAG already exists; leaving it unchanged."
-            exit 0
+            gh release upload "$TAG" "${files[@]}" --clobber
+          else
+            gh release create "$TAG" "${files[@]}" \
+              --title "SkillCorpus ${TAG#v}" \
+              --generate-notes
           fi
-          gh release create "$TAG" --title "SkillCorpus ${TAG#v}" --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
 
   publish-pypi:
     name: publish root package to PyPI
-    if: github.event_name == "push" && github.ref_type == "tag"
+    if: github.event_name == 'push' && github.ref_type == 'tag'
     needs: build
     runs-on: ubuntu-latest
     environment: release
@@ -117,7 +117,7 @@ jobs:
 
   github-release:
     name: create GitHub Release
-    if: github.event_name == "push" && github.ref_type == "tag"
+    if: github.event_name == 'push' && github.ref_type == 'tag'
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillcorpus"
-version = "0.1.0"
+version = "0.3.0"
 description = "SkillCorpus — an open pipeline that builds a corpus of agent skills"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/skillcorpus/__init__.py
+++ b/skillcorpus/__init__.py
@@ -22,4 +22,4 @@ __all__ = [
     "SkillRecord", "Category", "CATEGORIES",
     "SkillLibrary", "IngestResult", "IngestStatus",
 ]
-__version__ = "0.1.0"
+__version__ = "0.3.0"

--- a/skillcorpus_plugin/CHANGELOG.md
+++ b/skillcorpus_plugin/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 0.3.0
+## Unreleased
+
+## 0.3.0 — 2026-09-02
 
 ### Changed — read this before upgrading
 
@@ -34,7 +36,7 @@
   slot it claims is not upstream, and Raven ignores manifest keys it does not
   know. On-demand does not depend on it.
 
-## Unreleased
+## 0.2.0 — 2026-08-27
 
 ### Added
 

--- a/skillcorpus_plugin/scripts/verify_release_versions.py
+++ b/skillcorpus_plugin/scripts/verify_release_versions.py
@@ -6,9 +6,11 @@ import tarfile
 import zipfile
 from pathlib import Path
 
+import tomllib
+
 ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = ROOT.parent
-EXPECTED = "0.3.0"
+EXPECTED = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
 MARKETPLACE = json.loads(
     (REPO_ROOT / ".codebuddy-plugin/marketplace.json").read_text(encoding="utf-8")
 )
@@ -22,6 +24,12 @@ def text_version(path: str, pattern: str) -> str:
 
 
 versions = {
+    "root-package": EXPECTED,
+    "root-runtime": re.search(
+        r'^__version__ = "([^"]+)"',
+        (REPO_ROOT / "skillcorpus" / "__init__.py").read_text(encoding="utf-8"),
+        re.MULTILINE,
+    ).group(1),
     "engine-python": text_version("engine-python/pyproject.toml", r'^version = "([^"]+)"'),
     "raven": text_version("plugin-raven/pyproject.toml", r'^version = "([^"]+)"'),
     "hermes": text_version("plugin-hermes/plugin.yaml", r'^version: "([^"]+)"'),


### PR DESCRIPTION
## Summary

Prepare the unified SkillCorpus v0.3.0 release.

This release brings the corpus pipeline and all SkillCorpus agent plugins under one repository-level version and release process.

## What this PR does

- Aligns the root SkillCorpus package with version `0.3.0`.
- Finalizes the `0.3.0` changelog and records the historical `0.2.0` release.
- Builds Python wheel and source distributions for:
  - SkillCorpus
  - SkillSearch engine
  - Raven plugin
- Builds npm archives for:
  - OpenClaw 1.x
  - OpenClaw 2.0
  - WorkBuddy
- Builds a complete plugin bundle containing all host adapters, including Hermes and DeepSeek Harness.
- Generates `SHA256SUMS` for every release artifact.
- Runs the complete artifact build on release PRs and manual workflow runs.
- Creates or updates the GitHub Release when a matching `vX.Y.Z` tag is pushed.
- Keeps GitHub Release creation independent from PyPI publishing, so a PyPI configuration failure will not block downloadable release assets.

## Verification

Locally verified:

- Release version validation passed.
- Root wheel content validation passed.
- All Python wheel and source distributions passed `twine check`.
- All npm packages passed package-content validation and packed successfully.
- The complete plugin bundle contains:
  - WorkBuddy marketplace manifest and runtimes
  - OpenClaw 1.x and OpenClaw 2.0 runtimes
  - Hermes and Raven adapters
  - DeepSeek Harness source
- All generated artifacts passed SHA-256 verification.

After this PR is merged and the release-artifact CI is green, tag the merge commit as `v0.3.0`.