### PR TITLE
docs(release): add v0.3.0 release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,8 +134,13 @@ jobs:
         shell: bash
         run: |
           mapfile -d "" files < <(find release-assets -type f -print0 | sort -z)
+          notes_file="docs/releases/${TAG}.md"
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release upload "$TAG" "${files[@]}" --clobber
+          elif [[ -f "$notes_file" ]]; then
+            gh release create "$TAG" "${files[@]}" \
+              --title "SkillCorpus ${TAG#v}" \
+              --notes-file "$notes_file"
           else
             gh release create "$TAG" "${files[@]}" \
               --title "SkillCorpus ${TAG#v}" \

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,45 @@
+# SkillCorpus v0.3.0
+
+SkillCorpus v0.3.0 makes skill retrieval available when an agent actually needs
+it. It adds on-demand search across every supported host integration, alongside
+the existing automatic per-turn retrieval mode.
+
+## Highlights
+
+- **On-demand skill retrieval is now the default.** Agents receive a
+  `skill_search` tool and decide when to retrieve a skill. This avoids paying
+  for retrieval on turns that do not need it.
+- **Automatic retrieval remains available.** Set `mode: auto` to retain the
+  previous behavior: retrieve and inject matching skills before every turn.
+  The two modes are exclusive, so a turn never retrieves the same skill twice.
+- **OpenClaw 2.0 is supported.** OpenClaw 2.0 uses a dedicated context-engine
+  plugin; the existing OpenClaw plugin remains for 1.x hosts.
+- **Every host integration now supports on-demand retrieval:** OpenClaw 1.x,
+  OpenClaw 2.0, Hermes, Raven, DeepSeek Harness, and WorkBuddy. WorkBuddy
+  exposes the tool through its MCP integration.
+- **Complete release artifacts are attached to this release.** They include
+  the root Python distribution, Python engine and Raven-plugin distributions,
+  npm packages for OpenClaw and WorkBuddy, a full plugin bundle, and
+  `SHA256SUMS` checksums.
+
+## Upgrade notes
+
+**This is a behavior change for existing plugin installs.** With no explicit
+configuration, v0.3.0 uses `on_demand` rather than injecting skills on every
+turn. If your workflow depends on automatic retrieval, set `mode: auto` in
+your host plugin configuration. Every host also accepts `SKILLSEARCH_MODE=auto`.
+
+Choose the OpenClaw package that matches your host version:
+
+- `plugin-openclaw` for OpenClaw releases through 2026.7.x.
+- `plugin-openclaw2` for OpenClaw 2.0 (2026.8.1) and newer.
+
+Raven's on-demand mode works on the current upstream host. Its `auto` mode
+requires Raven's upstream `context_segments` slot, so use on-demand retrieval
+until that slot lands.
+
+## Learn more
+
+- [Install a host plugin](https://github.com/EverMind-AI/SkillCorpus/blob/v0.3.0/skillcorpus_plugin/INSTALL.agent.md)
+- [Read the detailed plugin changelog](https://github.com/EverMind-AI/SkillCorpus/blob/v0.3.0/skillcorpus_plugin/CHANGELOG.md)
+- [Review host end-to-end evidence](https://github.com/EverMind-AI/SkillCorpus/blob/v0.3.0/skillcorpus_plugin/tests/host-e2e/reports/0.3.0.md)


### PR DESCRIPTION
## Summary

- Adds the reviewed, user-facing SkillCorpus v0.3.0 release note.
- Covers the on-demand default, mode auto migration, OpenClaw 1.x versus 2.0 packaging, host coverage, artifacts, and Raven compatibility.
- Makes the release workflow use docs/releases/vX.Y.Z.md when it exists, while preserving generated GitHub notes as the fallback for later releases.

## Validation

- Verified the v0.3.0 note maps to the current root package version.
- Verified the release shell block syntax.
- git diff --check

This PR does not create a tag or publish a release.

Closes #17.