### PR TITLE
fix(release): checkout before creating GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      # gh release needs the repository remote, and version-specific release
+      # notes are read from the tagged checkout.
+      - uses: actions/checkout@v6
       - uses: actions/download-artifact@v4
         with:
           name: release-assets


### PR DESCRIPTION
## Problem

The v0.3.0 tag build completed, but the GitHub Release job had only downloaded artifacts. It had neither a repository remote for gh nor the version-specific release note file.

## Fix

Check out the tagged repository before downloading artifacts. The job can now discover the repository and read docs/releases/vX.Y.Z.md.

## Validation

- Verified checkout runs before artifact download.
- Verified the release shell block syntax.
- git diff --check

## v0.3.0 recovery

The verified v0.3.0 artifact set was manually published at https://github.com/EverMind-AI/SkillCorpus/releases/tag/v0.3.0. PyPI publishing remains separately blocked by the PyPI Trusted Publisher configuration.

Closes #19.