### PR TITLE
docs(release): align v0.3.0 notes

### DIFF
--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,45 +1,14 @@
-# SkillCorpus v0.3.0
+## What’s Changed
 
-SkillCorpus v0.3.0 makes skill retrieval available when an agent actually needs
-it. It adds on-demand search across every supported host integration, alongside
-the existing automatic per-turn retrieval mode.
+SkillCorpus v0.3.0 is the first unified release of the corpus pipeline and all supported agent-host plugins.
 
-## Highlights
+* Added on-demand `skill_search` across OpenClaw 1.x, OpenClaw 2.0, Hermes, Raven, DeepSeek Harness, and WorkBuddy, together with a dedicated OpenClaw 2.0 context-engine plugin, by @Tian-yi-Sun in https://github.com/EverMind-AI/SkillCorpus/pull/15
+* Unified the root package and plugin packages at version 0.3.0, with verified Python distributions, npm archives, a complete plugin bundle, and SHA-256 checksums, by @ypflll in https://github.com/EverMind-AI/SkillCorpus/pull/16
 
-- **On-demand skill retrieval is now the default.** Agents receive a
-  `skill_search` tool and decide when to retrieve a skill. This avoids paying
-  for retrieval on turns that do not need it.
-- **Automatic retrieval remains available.** Set `mode: auto` to retain the
-  previous behavior: retrieve and inject matching skills before every turn.
-  The two modes are exclusive, so a turn never retrieves the same skill twice.
-- **OpenClaw 2.0 is supported.** OpenClaw 2.0 uses a dedicated context-engine
-  plugin; the existing OpenClaw plugin remains for 1.x hosts.
-- **Every host integration now supports on-demand retrieval:** OpenClaw 1.x,
-  OpenClaw 2.0, Hermes, Raven, DeepSeek Harness, and WorkBuddy. WorkBuddy
-  exposes the tool through its MCP integration.
-- **Complete release artifacts are attached to this release.** They include
-  the root Python distribution, Python engine and Raven-plugin distributions,
-  npm packages for OpenClaw and WorkBuddy, a full plugin bundle, and
-  `SHA256SUMS` checksums.
+## Upgrade Note
 
-## Upgrade notes
+Skill retrieval now defaults to `on_demand`. Set `mode: auto` to retain automatic per-turn injection. OpenClaw 2.0 uses `plugin-openclaw2`; OpenClaw 1.x remains on `plugin-openclaw`.
 
-**This is a behavior change for existing plugin installs.** With no explicit
-configuration, v0.3.0 uses `on_demand` rather than injecting skills on every
-turn. If your workflow depends on automatic retrieval, set `mode: auto` in
-your host plugin configuration. Every host also accepts `SKILLSEARCH_MODE=auto`.
+Packages are currently distributed through this GitHub Release. PyPI and npm publication are not yet available.
 
-Choose the OpenClaw package that matches your host version:
-
-- `plugin-openclaw` for OpenClaw releases through 2026.7.x.
-- `plugin-openclaw2` for OpenClaw 2.0 (2026.8.1) and newer.
-
-Raven's on-demand mode works on the current upstream host. Its `auto` mode
-requires Raven's upstream `context_segments` slot, so use on-demand retrieval
-until that slot lands.
-
-## Learn more
-
-- [Install a host plugin](https://github.com/EverMind-AI/SkillCorpus/blob/v0.3.0/skillcorpus_plugin/INSTALL.agent.md)
-- [Read the detailed plugin changelog](https://github.com/EverMind-AI/SkillCorpus/blob/v0.3.0/skillcorpus_plugin/CHANGELOG.md)
-- [Review host end-to-end evidence](https://github.com/EverMind-AI/SkillCorpus/blob/v0.3.0/skillcorpus_plugin/tests/host-e2e/reports/0.3.0.md)
+**Full Changelog**: https://github.com/EverMind-AI/SkillCorpus/compare/skillcorpus-plugins-v0.2.0...v0.3.0


### PR DESCRIPTION
## Summary

- describe v0.3.0 as the first unified corpus-and-plugins release
- list only the user-facing work from PRs #15 and #16
- clarify the GitHub-only package availability and use the previous plugin release as the changelog baseline

## Verification

- `git diff --check`
- repository asset/media, file-size, and project-inventory gates
- `pytest -q skillcorpus/tests` (70 passed)
- no release tag or asset changes

Closes #21