### PR TITLE
fix(plugin-raven): track SearchConfig's top_k default of 2

### DIFF
--- a/skillcorpus_plugin/plugin-raven/skillsearch_raven/raven-plugin.toml
+++ b/skillcorpus_plugin/plugin-raven/skillsearch_raven/raven-plugin.toml
@@ -46,7 +46,10 @@ weight_local  = { type = "number",  default = 1.0 }
 weight_hub    = { type = "number",  default = 0.85 }
 over_fetch    = { type = "integer", default = 2 }
 dedup_by      = { type = "string",  enum = ["name", "qualified_id"], default = "qualified_id" }
-top_k         = { type = "integer", default = 5 }
+# Matches SearchConfig.top_k. Every other host defaults to 2; a 5 here made
+# Raven the one host that injected five bodies a turn, because the plugin
+# registry fills a declared default for every key the operator leaves out.
+top_k         = { type = "integer", default = 2 }
 
 # Narrowing. Both the rewriter and the gate need a model; leaving `model`
 # empty runs retrieval raw.


### PR DESCRIPTION
The multi-source release (#7) narrowed the `top_k` default from 5 to 2 across the
engine's `SearchConfig`, Hermes's `DEFAULTS`, and both TypeScript hosts' `topK`.
`raven-plugin.toml` is the one place that was left behind, and the line has not
been touched since the file was created.

Raven's plugin registry (`admit_slice`) fills a declared default for every key the
operator leaves out, so a zero-config Raven is the only host injecting five full
`SKILL.md` bodies per search where the other four inject two. On the default path
(`mode: on_demand` with an empty `model`) no gate is built either, so `pool_size`
collapses to `top_k` and those five are each source's top hit however weakly it
matched — RRF ranks by position within a source, not by match strength.

## Verification

Ran Raven's own `admit_slice` over the plugin's `config_schema` with an empty
operator slice: `top_k` resolves to 2 and now equals `SearchConfig().top_k`.
